### PR TITLE
proof-of-concept for building book using pretext-cli

### DIFF
--- a/project.ptx
+++ b/project.ptx
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file provides the overall configuration for your PreTeXt
+    project. To edit the content of your document, open `source/main.ptx`
+    (default location).
+-->
+<project>
+  <targets>
+    <target name="html">
+      <format>html</format>
+      <source>src/ula.xml</source>
+      <publication>pub/html.xml</publication>
+      <output-dir>output/html</output-dir>
+    </target>
+    <target name="subset">
+      <format>html</format>
+      <source>src/ula-subset.xml</source>
+      <publication>pub/html.xml</publication>
+      <output-dir>output/subset</output-dir>
+    </target>
+    <target name="latex">
+      <format>latex</format>
+      <source>src/ula.xml</source>
+      <publication>pub/latex.xml</publication>
+      <output-dir>output/latex</output-dir>
+    </target>
+    <target name="pdf">
+      <format>pdf</format>
+      <source>src/ula.xml</source>
+      <publication>pub/latex.xml</publication>
+      <output-dir>output/pdf</output-dir>
+    </target>
+  </targets>
+  <executables>
+      <tex>xelatex</tex>
+      <pdfsvg>pdf2svg</pdfsvg>
+      <asy>asy</asy>
+      <sage>sage</sage>
+      <pdfpng>convert</pdfpng>
+      <pdfeps>pdftops</pdfeps>
+      <pdfcrop>pdf-crop-margins</pdfcrop>
+      <pageres>pageres</pageres>
+      <node>node</node>
+      <liblouis>file2brl</liblouis>
+    </executables>
+</project>

--- a/pub/common.xml
+++ b/pub/common.xml
@@ -1,6 +1,0 @@
-<publication>
-  <common>
-    <tableofcontents level="2" />
-  </common>
-  <latex sides = "2" />
-</publication>

--- a/pub/html.xml
+++ b/pub/html.xml
@@ -1,5 +1,8 @@
 <publication xmlns:xi="http://www.w3.org/2001/XInclude">
-  <xi:include href="./common.xml" />
+    <source>
+        <!-- directories are relative to the main source PreTeXt file -->
+        <directories external="../assets" generated="../generated-assets"/>
+    </source>
   <html>
     <search google-cx="015103900096539427448:ngwuia10qci" />
     <css colors="blue_grey" />

--- a/pub/latex.xml
+++ b/pub/latex.xml
@@ -1,5 +1,12 @@
 <publication xmlns:xi="http://www.w3.org/2001/XInclude">
-  <xi:include href="./common.xml" />
+    <source>
+        <!-- directories are relative to the main source PreTeXt file -->
+        <directories external="../assets" generated="../generated-assets"/>
+    </source>
+  <common>
+    <tableofcontents level="2" />
+  </common>
+  <latex sides = "2" />
   <latex>
   </latex>
 </publication>

--- a/src/ula-subset.xml
+++ b/src/ula-subset.xml
@@ -6,15 +6,15 @@
   <book xml:id="ula">
     <title> Understanding Linear Algebra</title>
 
-    <xi:include href="./frontmatter.xml" />
+<!--    <xi:include href="./frontmatter.xml" />
     <xi:include href="./chap1.xml" />
     <xi:include href="./chap2.xml" />
     <xi:include href="./chap3.xml" />
     <xi:include href="./chap4.xml" />
-    <xi:include href="./chap5.xml" />
+    <xi:include href="./chap5.xml" /> -->
     <xi:include href="./chap6.xml" />
-    <xi:include href="./chap7.xml" />
-    <xi:include href="./backmatter.xml" />
+<!--     <xi:include href="./chap7.xml" />
+    <xi:include href="./backmatter.xml" /> -->
 
   </book>
 </pretext>


### PR DESCRIPTION
This isn't really meant to be merged (I haven't looked at your postprocessing script for instance), but I wanted to demo how you could eventually wire up your book with https://pretextbook.github.io/pretext-cli/ With this setup you can `pretext build html` to get the full book and `pretext build subset` to just build chapter 6.

As an aside, your book currently isn't importing pub/common.xml as I think you intend: you're basically putting a `<publication/>` inside of another `<publication/>`, so those imported settings are ignored. So that's why I moved those settings manually to your two pub files for this proof of concept.