### PR TITLE
Update exercise-28: clarify that \xvec is a vector

### DIFF
--- a/src/exercises/exercises2-2.xml
+++ b/src/exercises/exercises2-2.xml
@@ -82,7 +82,8 @@
 
   <exercise>
     <statement>
-      <p> Suppose that <m>A</m> is a <m>135\times2201</m> matrix.  If
+      <p> Suppose that <m>A</m> is a <m>135\times2201</m> matrix,
+      and that <m>\xvec</m> is a vector.  If
       <m>A\xvec</m> is defined, what is the dimension of <m>\xvec</m>?
       What is the dimension of <m>A\xvec</m>?
       </p>


### PR DESCRIPTION
Given the dimensions of a matrix A, exercise-28 asks students to think about the dimensions of x and Ax. It's customary for something called x to be a vector, but I think it's worth clarifying to eliminate ambiguity. If x could be a matrix (and a novice linear algebra student might think it could be), then x could have dimensions 2201 \times n, in which case Ax would have dimensions 135 \times n.