### PR TITLE
Remove google based search box

### DIFF
--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -4,7 +4,6 @@
     <version include="production"/>
   </source>
   <html>
-    <search google-cx="015103900096539427448:ngwuia10qci" />
     <css
       theme="default-modern"
       palette="blue-green"

--- a/publication/runestone-proteus-dev.ptx
+++ b/publication/runestone-proteus-dev.ptx
@@ -4,7 +4,6 @@
     <version include="proteus-id proteus proteus-subtitle rs-preview"/>
   </source>
   <html>
-    <search google-cx="015103900096539427448:ngwuia10qci" />
     <css theme="salem" palette="ice-fire" />
     <!-- Examples and exercises are knowlized by default -->
     <!-- We disable this behavior  -->

--- a/publication/runestone-proteus-playground-dev.ptx
+++ b/publication/runestone-proteus-playground-dev.ptx
@@ -4,7 +4,6 @@
     <version include="proteus-playground proteus proteus-playground-subtitle"/>
   </source>
   <html>
-    <search google-cx="015103900096539427448:ngwuia10qci" />
     <css theme="salem" palette="ice-fire"/>
     <!-- Examples and exercises are knowlized by default -->
     <!-- We disable this behavior  -->

--- a/publication/runestone-proteus-playground.ptx
+++ b/publication/runestone-proteus-playground.ptx
@@ -5,7 +5,6 @@
   </source>
   <html>
     <platform host="runestone"/>
-    <search google-cx="015103900096539427448:ngwuia10qci" />
     <css theme="salem" palette="ice-fire"/>
     <!-- Examples and exercises are knowlized by default -->
     <!-- We disable this behavior  -->

--- a/publication/runestone-proteus.ptx
+++ b/publication/runestone-proteus.ptx
@@ -5,7 +5,6 @@
   </source>
   <html>
     <platform host="runestone"/>
-    <search google-cx="015103900096539427448:ngwuia10qci" />
     <css theme="salem" palette="ice-fire"/>
     <!-- Examples and exercises are knowlized by default -->
     <!-- We disable this behavior  -->

--- a/publication/runestone.ptx
+++ b/publication/runestone.ptx
@@ -5,7 +5,6 @@
   </source>
   <html>
     <platform host="runestone"/>
-    <search google-cx="015103900096539427448:ngwuia10qci" />
     <css colors="blue_grey" />
     <!-- Examples and exercises are knowlized by default -->
     <!-- We disable this behavior  -->


### PR DESCRIPTION
I noticed that you have both the standard PreTeXt based search enabled and the google search.  I think the native search is really good now, and having both causes UI issues on small screens.  This PR removes the google search from the various publication files that had it.