### PR TITLE
reflow sidebyside equations

### DIFF
--- a/src/section1-2.xml
+++ b/src/section1-2.xml
@@ -326,8 +326,7 @@
 	  \end{array}
 	</me>
 	to obtain
-	<sidebyside widths="30% 30% 30%" valign="middle">
-	  <p>
+
 	    <me>
 	      \begin{array}{cr}
 	      \amp -2(x+2y=1) \\
@@ -336,9 +335,9 @@
 	      \\
 	      \end{array}
 	    </me>
-	  </p>
-	  <p> which gives us </p>
-	  <p>
+
+	 which gives us 
+
 	    <me>
 	      \begin{array}{crcr}
 	      \amp -2x-4y \amp = \amp -2 \\
@@ -347,8 +346,6 @@
 	      \amp -y \amp = \amp 1. \\
 	      \end{array}
 	    </me>
-	  </p>
-	</sidebyside>
       </p>
       
       <p>


### PR DESCRIPTION
I completely understand if you would rather not accept this suggestion, but every time I see the middle of [Observation 1.2.3](https://understandinglinearalgebra.org/sec-finding-solutions.html#sec-finding-solutions-3-7) I get confused by the sidebyside inside the paragraph.  This reflows that as a sequence of two more `<me>`.

Technically PreTeXt doesn't allow a sidebyside inside a `<p>`, by the way.