### PR TITLE
Fix typo

### DIFF
--- a/src/section3-2.xml
+++ b/src/section3-2.xml
@@ -503,11 +503,11 @@
 	then
 	<me>
 	  \xvec = 5\vvec_1 - 2\vvec_2 = 5\twovec{2}{1}-2\twovec{1}{2}
-	  = \twovec{8}{3},
+	  = \twovec{8}{1},
 	</me>
 	and we conclude that
 	<me>
-	  \coords{\twovec{8}{3}}{\bcal} = \twovec{5}{-2}
+	  \coords{\twovec{8}{1}}{\bcal} = \twovec{5}{-2}
 	</me>.
 	This demonstrates how we can translate coordinates in the
 	basis <m>\bcal</m> into standard coordinates.


### PR DESCRIPTION
One of my students noticed a small typo: in this [Paragraph](https://understandinglinearalgebra.org/sec-bases.html#sec-bases-4-3-1-5), the second coordinate of the vector (in the standard basis) should be `5*1 - 2*2 = 1`, not 3. 
