### PR TITLE
Fix typo (missing subscript)

### DIFF
--- a/src/section3-5.xml
+++ b/src/section3-5.xml
@@ -529,7 +529,7 @@
 	  \end{bmatrix}.
 	</me>
 	From the reduced row echelon form of the matrix, we see that
-	<m>\vvec_2 = -\vvec</m>.  Therefore, any linear combination
+	<m>\vvec_2 = -\vvec_1</m>.  Therefore, any linear combination
 	of <m>\vvec_1</m>, <m>\vvec_2</m>, and <m>\vvec_3</m> can be
 	rewritten 
 	<me>


### PR DESCRIPTION
The sentence after the display equation in [Example 3.5.5: A subspace of \real^4](https://understandinglinearalgebra.org/sec-subspaces.html#sec-subspaces-3-9) is missing the subscript for `v_1`.