### PR TITLE
Fix invalid PreFigure labels, a namespace typo, and a stray <P>

### DIFF
--- a/src/exercises/exercises2-6.xml
+++ b/src/exercises/exercises2-6.xml
@@ -321,8 +321,8 @@
 	  vectors by <m>90^\circ</m> around the
 	  <m>y</m>-axis. </p></li>
 
-	  <li><P> Find the matrix that rotates vectors by
-	  <m>90^\circ</m> around the <m>z</m>-axis. </P></li>
+	  <li><p> Find the matrix that rotates vectors by
+	  <m>90^\circ</m> around the <m>z</m>-axis. </p></li>
 
 	  <li><p> What is the cumulative effect of rotating by
 	  <m>90^\circ</m> about the <m>x</m>-axis, followed by a

--- a/src/section3-4.xml
+++ b/src/section3-4.xml
@@ -67,7 +67,7 @@
           segment drawn from a vertex on the top side to the bottom
           side has length <m>h</m>.</p>
         </description>
-        <prefigure xmlns="Https://prefigure.org"
+        <prefigure xmlns="https://prefigure.org"
                    label="pf-parallelogram-area">
           <xi:include href="prefigure/section3-4/parallelogram-area.xml"/>
         </prefigure>
@@ -627,7 +627,7 @@
               <m>(2,0)</m>, <m>(4,3)</m>, and <m>(2,3)</m>.</p>
             </description>
             <prefigure xmlns="https://prefigure.org"
-                       label="pf-parallelogram-f.xml">
+                       label="pf-parallelogram-f">
               <xi:include
                   href="prefigure/section3-4/parallelogram-f.xml"/>
             </prefigure>
@@ -641,7 +641,7 @@
               <m>(2,0)</m>, <m>(2,3)</m>, and <m>(0,3)</m>.</p>
             </description>
             <prefigure xmlns="https://prefigure.org"
-                       label="pf-parallelogram-g.xml">
+                       label="pf-parallelogram-g">
               <xi:include
                   href="prefigure/section3-4/parallelogram-g.xml"/>
             </prefigure>


### PR DESCRIPTION
Three small source-markup fixes, surfaced while building the book through PreTeXt's new XSL-FO → PDF route (Apache FOP). None are FO-specific — all are correctness issues in the existing source:

- **`src/section3-4.xml`** — the `<prefigure>` for the parallelogram-area figure declared its namespace as `Https://prefigure.org` (capital **H**). XML namespaces are case-sensitive, so PreTeXt never recognized it as a PreFigure diagram: it was silently dropped from **every** output format and never generated. Fixed to `https://prefigure.org`.
- **`src/section3-4.xml`** — the `parallelogram-f` and `parallelogram-g` `<prefigure>` elements carried `@label` values ending in `.xml` (`pf-parallelogram-f.xml`, `pf-parallelogram-g.xml`). The label becomes the generated image's filename, so the `.xml` suffix produces an invalid label/filename. Dropped the suffix.
- **`src/exercises/exercises2-6.xml`** — an exercise item used `<P>…</P>` (capital) instead of `<p>…</p>`.

Two files, five lines. Verified with an XSL-FO build plus a full PreFigure image generation: the parallelogram-area diagram (previously dropped everywhere) now comes through, and the two relabeled diagrams generate under their corrected filenames.

*Claude Opus 4.8, acting as a coding assistant for Rob Beezer*
