### PR TITLE
fix: correct typo 'prodct' to 'product' in section6-1.xml

### DIFF
--- a/src/section6-1.xml
+++ b/src/section6-1.xml
@@ -2377,7 +2377,7 @@ plotclusters(clusters, centroids)
 
     <exercise component="proteus-playground"
               label="ula-proteus-6-1-proofmagnitudesquared-v1">
-      <title>Proving the relationship between dot prodct and
+      <title>Proving the relationship between dot product and
       magnitude</title>
       <statement>
         <p>Suppose <m>\vvec=\twovec{x_1}{x_2}</m>. Prove


### PR DESCRIPTION
## Summary
Correct typo in the title of exercise `ula-proteus-6-1-proofmagnitudesquared-v1`: 'prodct' → 'product' in section 6.1 Checkpoint (dot product section).

## Fix
- File: `src/section6-1.xml`
- Change: `dot prodct` → `dot product`
- Issue: #78

## Verification
```bash
git diff src/section6-1.xml
```
Shows 1 line changed: 'prodct' → 'product' in the exercise title.