### PR TITLE
reordered #figure elements with #caption first

### DIFF
--- a/src/exercises/exercises2-1.xml
+++ b/src/exercises/exercises2-1.xml
@@ -14,6 +14,7 @@
             Sketch these vectors below.
           </p>
           <figure>
+            <caption>A coordinate grid and axes for sketching vectors.</caption>
 	    <image width="50%">
               <shortdescription>
                 A coordinate grid and axes for
@@ -32,7 +33,6 @@
                 <xi:include href="prefigure/empty-6.xml"/>
               </prefigure>
             </image>
-            <caption>A coordinate grid and axes for sketching vectors.</caption>
           </figure>
         </li>
 
@@ -48,6 +48,7 @@
 	    c\wvec</m> where <m>c</m> is any scalar.
           </p>
           <figure>
+            <caption>A coordinate grid and axes for sketching vectors.</caption>
 	    <image width="50%">
               <shortdescription>
                 A coordinate grid and axes for
@@ -66,7 +67,6 @@
                 <xi:include href="prefigure/empty-6.xml"/>
               </prefigure>
             </image>
-            <caption>A coordinate grid and axes for sketching vectors.</caption>
           </figure>
         </li>
 
@@ -78,6 +78,7 @@
 	    choices for the vectors <m>\vvec</m> and <m>\wvec</m>?
           </p>
           <figure>
+            <caption>A coordinate grid and axes for sketching vectors.</caption>
 	    <image width="50%">
               <shortdescription>
                 A coordinate grid and axes for
@@ -96,7 +97,6 @@
                 <xi:include href="prefigure/empty-6.xml"/>
               </prefigure>
             </image>
-            <caption>A coordinate grid and axes for sketching vectors.</caption>
           </figure>
         </li>
       </ol>
@@ -176,6 +176,9 @@
         Shown below are two vectors <m>\vvec</m> and <m>\wvec</m>.
       </p>
       <figure>
+        <caption>
+          Two vectors <m>\vvec</m> and <m>\wvec</m>.
+        </caption>
 	<image width="50%">
           <shortdescription>
             Two vectors and the skewed grid of parallel lines they
@@ -197,9 +200,6 @@
             <xi:include href="prefigure/ex-linear-combs-2-1.xml"/>
           </prefigure>
         </image>
-        <caption>
-          Two vectors <m>\vvec</m> and <m>\wvec</m>.
-        </caption>
       </figure>
       <p>
         <ol marker="a.">

--- a/src/exercises/exercises2-2.xml
+++ b/src/exercises/exercises2-2.xml
@@ -191,6 +191,9 @@
       </p>
 
       <figure xml:id="ex-eq-graphical">
+	<caption> Two vectors <m>\vvec_1</m> and <m>\vvec_2</m> that
+	form the columns of the matrix <m>A</m>. 
+	</caption>
 	<image width="60%">
           <shortdescription>Two vectors v one and v two and their linear combinations</shortdescription>
           <description>
@@ -204,9 +207,6 @@
             <xi:include href="prefigure/ex-matrix-cols-2-2.xml"/>
           </prefigure>
         </image>
-	<caption> Two vectors <m>\vvec_1</m> and <m>\vvec_2</m> that
-	form the columns of the matrix <m>A</m>. 
-	</caption>
       </figure>
 
       <p>

--- a/src/exercises/exercises2-5.xml
+++ b/src/exercises/exercises2-5.xml
@@ -253,6 +253,9 @@
       </p>
 
       <figure xml:id="fig-ex-linear-trans">
+	<caption>
+	  The vectors <m>T(\evec_j)=\vvec_j</m>.
+	</caption>
 	<image width="50%">
           <shortdescription>
             Three two dimensional vectors.
@@ -272,9 +275,6 @@
             <xi:include href="prefigure/ex-linear-trans-2-5.xml"/>
           </prefigure>
         </image>
-	<caption>
-	  The vectors <m>T(\evec_j)=\vvec_j</m>.
-	</caption>
       </figure>
 
       <p> <ol marker="a.">

--- a/src/exercises/exercises2-6.xml
+++ b/src/exercises/exercises2-6.xml
@@ -281,6 +281,11 @@
       </p>
 
       <figure xml:id="fig-3d-basis">
+	<caption>
+	  The vectors 
+	  <m>\evec_1</m>, <m>\evec_2</m>, and 
+	  <m>\evec_3</m> in <m>\real^3</m>.
+	</caption>
 	<image width="50%">
           <shortdescription>
             A set of three dimensional coordinate axes with a vector
@@ -300,11 +305,6 @@
           </prefigure>
         </image>
 
-	<caption>
-	  The vectors 
-	  <m>\evec_1</m>, <m>\evec_2</m>, and 
-	  <m>\evec_3</m> in <m>\real^3</m>.
-	</caption>
       </figure>
       
       <p>
@@ -625,6 +625,11 @@
       </p>
 
       <figure xml:id="fig-ex-rotate-about-p">
+	<caption>
+	  A sequence of matrix transformations that, when read right
+	  to left and top to bottom, rotate a vector about the point
+	  <m>(1,2)</m>. 
+	</caption>
 	<sbsgroup widths="45% 45%">
           <sidebyside>
 	    <image>
@@ -682,11 +687,6 @@
             </image>
 	  </sidebyside>
         </sbsgroup>
-	<caption>
-	  A sequence of matrix transformations that, when read right
-	  to left and top to bottom, rotate a vector about the point
-	  <m>(1,2)</m>. 
-	</caption>
       </figure>
 
       <p> Remember that, when working with homogeneous
@@ -849,6 +849,9 @@
       </p>
       
       <figure xml:id="fig-ex-projection">
+	<caption>
+	  Projection onto the <m>x</m>-axis.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image>
             <shortdescription>
@@ -879,9 +882,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption>
-	  Projection onto the <m>x</m>-axis.
-	</caption>
       </figure>
 
       <p><ol marker="a.">
@@ -1085,6 +1085,10 @@
       </p>
 
       <figure xml:id="fig-ex-complex-polar">
+	<caption>
+	  A vector may be expressed in polar
+	  coordinates.
+	</caption>
 	<sidebyside width="50%">
 	  <image>
             <shortdescription>
@@ -1103,10 +1107,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption>
-	  A vector may be expressed in polar
-	  coordinates.
-	</caption>
       </figure>
 
       <p> We then have
@@ -1294,6 +1294,9 @@
       </p>
 
       <figure xml:id="fig-ex-reflection-def">
+	<caption>
+	  The reflection across the line <m>L_\theta</m>.
+	</caption>
 	<image width="50%">
           <shortdescription>
             A line, a vector x, and the result of reflecting x in
@@ -1312,9 +1315,6 @@
             <xi:include href="prefigure/ex-reflection-def.xml"/>
           </prefigure>
         </image>
-	<caption>
-	  The reflection across the line <m>L_\theta</m>.
-	</caption>
       </figure>
 
       <p>
@@ -1331,6 +1331,10 @@
 	<m>L_\theta</m>. 
       </p>     
       <figure xml:id="fig-ex-reflection-compose">
+	<caption>
+	  Reflection in the line <m>L_\theta</m> as a composition of three
+	  transformations.
+	</caption>
         <sbsgroup widths="45% 45%">
 	  <sidebyside>
 	    <image>
@@ -1400,10 +1404,6 @@
             </image>
 	  </sidebyside>
         </sbsgroup>
-	<caption>
-	  Reflection in the line <m>L_\theta</m> as a composition of three
-	  transformations.
-	</caption>
       </figure>
 
       <p>

--- a/src/exercises/exercises3-2.xml
+++ b/src/exercises/exercises3-2.xml
@@ -9,6 +9,10 @@
       </p>
 
       <figure xml:id="fig-ex-basis">
+	<caption>
+	  Vectors <m>\vvec_1</m> and <m>\vvec_2</m> in
+	  <m>\real^2</m>.
+	</caption>
 	<image width="60%">
           <shortdescription>
             Two vectors and the skewed grid of linear combinations
@@ -26,10 +30,6 @@
             <xi:include href="prefigure/ex-basis-3-2.xml"/>
           </prefigure>
         </image>
-	<caption>
-	  Vectors <m>\vvec_1</m> and <m>\vvec_2</m> in
-	  <m>\real^2</m>.
-	</caption>
       </figure>
 
       <p><ol marker="a.">
@@ -735,6 +735,9 @@
       </p>
 
       <figure xml:id="fig-ex-graphite">
+	<caption>
+	  A layer of carbon atoms in a graphite crystal.
+	</caption>
 	<image width="60%">
           <shortdescription>
             The hexagonal array of carbon atoms in a layer of
@@ -765,9 +768,6 @@
             <xi:include href="prefigure/ex-graphite.xml"/>
           </prefigure>
         </image>
-	<caption>
-	  A layer of carbon atoms in a graphite crystal.
-	</caption>
       </figure>
 
       <p> The origin of the coordinate system is at the carbon atom

--- a/src/exercises/exercises3-3.xml
+++ b/src/exercises/exercises3-3.xml
@@ -296,6 +296,10 @@ print (Pinv.numerical_approx(digits=3))
       </p>
 
       <figure xml:id="fig-fourier-sine-basis">
+	<caption>
+	  The vectors <m>\vvec_1,\vvec_2,\vvec_3,\vvec_4</m>
+	  that form the basis <m>\scal</m>.
+	</caption>
         <sbsgroup widths="45% 45%">
 	  <sidebyside>
 	    <image>
@@ -357,10 +361,6 @@ print (Pinv.numerical_approx(digits=3))
             </image>
           </sidebyside>
         </sbsgroup>
-	<caption>
-	  The vectors <m>\vvec_1,\vvec_2,\vvec_3,\vvec_4</m>
-	  that form the basis <m>\scal</m>.
-	</caption>
       </figure>
 
       <p><ol marker="a.">
@@ -514,6 +514,8 @@ C = matrix(cosmat).numerical_approx()
       </p>
 
       <figure xml:id="fig-haar-wavelet-basis">
+	<caption> The Haar wavelet basis represented graphically.
+	</caption>
 	  <sbsgroup widths="40% 40%%">
             <sidebyside>
 	      <image>
@@ -575,8 +577,6 @@ C = matrix(cosmat).numerical_approx()
               </image>
 	    </sidebyside>
           </sbsgroup>
-	<caption> The Haar wavelet basis represented graphically.
-	</caption>
       </figure>
 
       <p> The change of coordinates from a vector <m>\xvec</m> in

--- a/src/exercises/exercises4-5.xml
+++ b/src/exercises/exercises4-5.xml
@@ -121,6 +121,10 @@
       in <xref ref="fig-stoch-pops" />. </p>
 
       <figure xml:id="fig-stoch-pops">
+	<caption>
+	  The flow between urban, suburban, and rural
+	  populations. 
+	</caption>
 	<image width="50%">
           <shortdescription>
             A description of how people move between urban, suburban,
@@ -145,10 +149,6 @@
             <xi:include href="prefigure/ex-stoch-pops.xml"/>
           </prefigure>
         </image>
-	<caption>
-	  The flow between urban, suburban, and rural
-	  populations. 
-	</caption>
       </figure>
 
       <p>
@@ -866,6 +866,10 @@ modified_markov_chain(G, x0, 20)
 	  on square 8, we will stay there forever.  </p>
 
 	  <figure xml:id="fig-chutes-plain">
+	    <caption>
+	      A simple version of Chutes and Ladders with neither chutes
+	      nor ladders.
+	    </caption>
 	    <image width="50%">
               <shortdescription>
                 Eight squares in a row labelled from one to eight
@@ -881,10 +885,6 @@ modified_markov_chain(G, x0, 20)
                 <xi:include href="prefigure/chutes-plain.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      A simple version of Chutes and Ladders with neither chutes
-	      nor ladders.
-	    </caption>
 	  </figure>
 
 	  <p> Construct the <m>8\times8</m> matrix <m>A</m> that
@@ -919,6 +919,10 @@ markov_chain(A, x0, 10)
 	  </p>
 
 	  <figure xml:id="fig-chutes-ladders">
+	    <caption>
+	      A version of Chutes and Ladders with one chute and one
+	      ladder. 
+	    </caption>
 	    <image width="50%">
               <shortdescription>
                 A simple version of Chutes and Ladders.
@@ -941,10 +945,6 @@ markov_chain(A, x0, 10)
                 <xi:include href="prefigure/chutes-ladders.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      A version of Chutes and Ladders with one chute and one
-	      ladder. 
-	    </caption>
 	  </figure>
 
 	  <p> Even though there are eight squares, we only need to

--- a/src/exercises/exercises6-1.xml
+++ b/src/exercises/exercises6-1.xml
@@ -896,6 +896,10 @@
 	exercise, we will see how this expression arises
 	geometrically.
 	<figure xml:id ="fig-ex-eq-line">
+	  <caption>
+	    A line, a point <m>\pvec</m> on the line, and a vector
+	    <m>\nvec</m> perpendicular to the line.
+	  </caption>
 	  <image width="50%">
             <shortdescription>
               A line with three vectors used to develop an equation
@@ -917,10 +921,6 @@
               <xi:include href="prefigure/ex-eq-line.xml"/>
             </prefigure>
           </image>
-	  <caption>
-	    A line, a point <m>\pvec</m> on the line, and a vector
-	    <m>\nvec</m> perpendicular to the line.
-	  </caption>
 	</figure>
 	<ol marker="a.">
 	  <li>

--- a/src/exercises/exercises7-1.xml
+++ b/src/exercises/exercises7-1.xml
@@ -753,6 +753,9 @@
 	      Find the matrix <m>A</m> of demeaned data points and
 	      plot the points in <xref ref="ex-demean-plot"/>.
 	      <figure xml:id="ex-demean-plot">
+                <caption>
+		  A plot for the demeaned data points.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A standard coordinate grid and set of axes.
@@ -767,9 +770,6 @@
                     <xi:include href="prefigure/empty-4.xml"/>
                   </prefigure>
                 </image>
-                <caption>
-		  A plot for the demeaned data points.
-		</caption>
 	      </figure>
 	    </p>
 	  </li>

--- a/src/exercises/exercises7-3.xml
+++ b/src/exercises/exercises7-3.xml
@@ -480,6 +480,12 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
       </p>
       
       <figure xml:id="fig-penguins">
+	<caption>
+	  Artwork by <url
+	  href="https://github.com/allisonhorst/palmerpenguins/blob/master/README.md"
+	  visual="gvsu.edu/s/21G">
+	  @allison_horst </url>
+	</caption>
 	<sidebyside widths="55% 35%">
 	  <image source="images/lter_penguins.png">
             <shortdescription>
@@ -503,12 +509,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
             </description>
           </image>
 	</sidebyside>
-	<caption>
-	  Artwork by <url
-	  href="https://github.com/allisonhorst/palmerpenguins/blob/master/README.md"
-	  visual="gvsu.edu/s/21G">
-	  @allison_horst </url>
-	</caption>
       </figure>
 
       <p>

--- a/src/section2-1.xml
+++ b/src/section2-1.xml
@@ -358,6 +358,8 @@
       a vector <m>\vvec</m> lies on the same line defined by
       <m>\vvec</m>. 
       <figure xml:id="fig-scalar-mult">
+	<caption> Scalar multiples of the vector <m>\vvec=\twovec21</m>.
+	</caption>
 	<image width="50%">
           <shortdescription>
             A vector and several scalar multiples all of which lie
@@ -375,8 +377,6 @@
             <xi:include href="prefigure/section2-1/scalar-mult.xml"/>
           </prefigure>
         </image>
-	<caption> Scalar multiples of the vector <m>\vvec=\twovec21</m>.
-	</caption>
       </figure>
     </p>
 
@@ -461,6 +461,9 @@
       the line <m> c\vvec</m> by the vector <m>\wvec</m>, as shown in
       <xref ref="fig-parametric-line" />.
       <figure xml:id="fig-parametric-line">
+	<caption> The set of vectors <m>c\vvec + \wvec</m> form a
+	line.
+	</caption>
 	<image width="50%">
           <shortdescription>
             Representations of vectors obtained by multiplying one
@@ -483,9 +486,6 @@
             <xi:include href="prefigure/section2-1/line-param.xml"/>
           </prefigure>
           </image>
-	<caption> The set of vectors <m>c\vvec + \wvec</m> form a
-	line.
-	</caption>
       </figure>
     </p>
 

--- a/src/section2-5.xml
+++ b/src/section2-5.xml
@@ -90,6 +90,9 @@
 	  <xref ref="fig-graph-square"/>.</p>
 
 	  <figure xml:id="fig-graph-square">
+	    <caption>
+	      Graph the function <m>f(x)=x^2</m> above.
+	    </caption>
 	    <image width="50%">
               <shortdescription>
                 A coordinate grid and set of axes.
@@ -105,9 +108,6 @@
                 <xi:include href="prefigure/section1-1/empty-4.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      Graph the function <m>f(x)=x^2</m> above.
-	    </caption>
 	  </figure>
           <p component="rs-preview">You can scan your graph and attach
           it below.

--- a/src/section2-6.xml
+++ b/src/section2-6.xml
@@ -25,6 +25,8 @@
         <m>T(\xvec)</m>. </p>
 
         <figure xml:id="fig-reflect-intro">
+	  <caption> A vector <m>\xvec</m> and its reflection
+	  <m>T(\xvec)</m> across the horizontal axis. </caption>
 	  <image width="50%">
             <shortdescription>
               A two dimensional vector and its reflection across the
@@ -40,8 +42,6 @@
               <xi:include href="prefigure/section2-6/reflect-intro.xml"/>
             </prefigure>
           </image>
-	  <caption> A vector <m>\xvec</m> and its reflection
-	  <m>T(\xvec)</m> across the horizontal axis. </caption>
         </figure>
       </introduction>
 
@@ -499,6 +499,10 @@
 	</p>
 
 	<figure xml:id="fig-45-rotation">
+	  <caption>
+	    The function <m>T</m> rotates a vector counterclockwise by
+	    <m>45^\circ</m>.
+	  </caption>
 	  <sidebyside widths = "45% 45%">
 	    <image>
               <shortdescription>
@@ -527,10 +531,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    The function <m>T</m> rotates a vector counterclockwise by
-	    <m>45^\circ</m>.
-	  </caption>
 	</figure>
 	
 	<p>
@@ -557,6 +557,11 @@
 	</p>
 
 	<figure xml:id="fig-45-rotation-linear-mult">
+	  <caption>
+	    We see that the vector <m>T(c\vvec)</m> is a scalar
+	    multiple to <m>T(\vvec)</m> so that <m>T(c\vvec) =
+	    cT(\vvec)</m>.
+	  </caption>
 	  <sidebyside widths="45% 45%">
 	    <image>
               <shortdescription>
@@ -588,11 +593,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    We see that the vector <m>T(c\vvec)</m> is a scalar
-	    multiple to <m>T(\vvec)</m> so that <m>T(c\vvec) =
-	    cT(\vvec)</m>.
-	  </caption>
 	</figure>
 
 	<p>
@@ -609,6 +609,11 @@
 	</p>
 	
 	<figure xml:id="fig-45-rotation-linear-add">
+	  <caption>
+	    We see that the vector <m>T(\vvec+\wvec)</m> is the
+	    sum of <m>T(\vvec)</m> and <m>T(\wvec)</m> so that 
+	    <m>T(\vvec + \wvec) = T(\vvec) + T(\wvec)</m>.
+	  </caption>
 	  <sidebyside widths="45% 45%">
 	    <image>
               <shortdescription>
@@ -647,11 +652,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    We see that the vector <m>T(\vvec+\wvec)</m> is the
-	    sum of <m>T(\vvec)</m> and <m>T(\wvec)</m> so that 
-	    <m>T(\vvec + \wvec) = T(\vvec) + T(\wvec)</m>.
-	  </caption>
 	</figure>
 
 	<p>
@@ -667,6 +667,10 @@
 	</p>
 
 	<figure xml:id="fig-45-rotation-basis">
+	  <caption>
+	    The matrix transformation <m>T</m> rotates <m>\evec_1</m>
+	    and <m>\evec_2</m> by <m>45^\circ</m>.
+	  </caption>
 	  <sidebyside widths="45% 45%">
 	    <image>
               <shortdescription>
@@ -699,10 +703,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    The matrix transformation <m>T</m> rotates <m>\evec_1</m>
-	    and <m>\evec_2</m> by <m>45^\circ</m>.
-	  </caption>
 	</figure>
 
 	<p> Notice that <m>T(\evec_1)</m> forms an isosceles right
@@ -714,6 +714,11 @@
 	</p>
 
 	<figure xml:id="fig-45-rotation-e1">
+	  <caption>
+	    The vector <m>T(\evec_1)</m> has length 1 and is the
+	    hypotenuse of a right isosceles
+	    triangle.
+	  </caption>
 	  <image width="50%">
             <shortdescription>
               The vector obtained by rotating e 1 counterclockwise
@@ -736,11 +741,6 @@
                     href="prefigure/section2-6/45-rotation-e1.xml"/>
             </prefigure>
           </image>
-	  <caption>
-	    The vector <m>T(\evec_1)</m> has length 1 and is the
-	    hypotenuse of a right isosceles
-	    triangle.
-	  </caption>
 	</figure>
 
 	<p>
@@ -953,6 +953,11 @@
     </p>
 
     <figure xml:id="fig-blob-man">
+      <caption>
+	Computer animators define a character and 
+	create motion by drawing it in a sequence of poses.
+	<copyright /> Disney/Pixar
+      </caption>
       <sidebyside widths="45% 45%">
 	<image source="images/char-bind.jpg">
           <shortdescription>
@@ -979,11 +984,6 @@
           </description>
         </image>
       </sidebyside>
-      <caption>
-	Computer animators define a character and 
-	create motion by drawing it in a sequence of poses.
-	<copyright /> Disney/Pixar
-      </caption>
     </figure>
 
     <!--
@@ -1046,6 +1046,9 @@
     </p>
     
     <figure xml:id="fig-animate-translate">
+      <caption>
+	Translating our character to a new position in the plane.
+      </caption>
       <image width="45%">
         <shortdescription>
           The character has been translated two units horizontally
@@ -1060,9 +1063,6 @@
           <xi:include href="prefigure/section2-6/animate-translate.xml"/>
         </prefigure>
       </image>
-      <caption>
-	Translating our character to a new position in the plane.
-      </caption>
     </figure>
 
     <p>
@@ -1079,6 +1079,11 @@
     </p>
 
     <figure xml:id="fig-animate-homogeneous">
+      <caption>
+	We include the two-dimensional coordinate plane in <m>\real^3</m>
+	as the plane <m>z=1</m> so that we can translate the
+	character.
+      </caption>
       <image width="70%">
         <shortdescription>
           A three dimensional figure showing the two dimensional
@@ -1098,11 +1103,6 @@
               href="prefigure/section2-6/animate-homogeneous.xml"/>
         </prefigure>
       </image>
-      <caption>
-	We include the two-dimensional coordinate plane in <m>\real^3</m>
-	as the plane <m>z=1</m> so that we can translate the
-	character.
-      </caption>
     </figure>
 
     <p>
@@ -1260,6 +1260,9 @@
 	</p>
 
 	<figure xml:id="fig-animate-translate-2">
+	  <caption>
+	    Translating to a new position.
+	  </caption>
 	  <sidebyside widths="40% 40%">
 	    <image>
               <shortdescription>
@@ -1291,9 +1294,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    Translating to a new position.
-	  </caption>
 	</figure>
 	</li>
 
@@ -1305,6 +1305,9 @@
 	</p>
 
 	<figure xml:id="fig-animate-reflect">
+	  <caption>
+	    Waving with the other hand.
+	  </caption>
 	  <sidebyside widths="40% 40%">
 	    <image>
               <shortdescription>
@@ -1336,9 +1339,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    Waving with the other hand.
-	  </caption>
 	</figure>
 	</li>
 
@@ -1348,6 +1348,9 @@
 	</p>
 
 	<figure xml:id="fig-animate-rotate">
+	  <caption>
+	    Performing a cartwheel.
+	  </caption>
 	  <sbsgroup widths="40% 40%">
 	    <sidebyside>
 	      <image>
@@ -1414,9 +1417,6 @@
               </image>
 	    </sidebyside>
 	  </sbsgroup>
-	  <caption>
-	    Performing a cartwheel.
-	  </caption>
 	</figure>
 	</li>
 
@@ -1433,6 +1433,9 @@
       </p>
 
 	<figure xml:id="fig-animate-closeup">
+	  <caption>
+	    Zooming in on our characters' face.
+	  </caption>
 	  <sbsgroup widths="40% 40%">
 	    <sidebyside>
 	      <image>
@@ -1502,9 +1505,6 @@
               </image>
 	    </sidebyside>
 	  </sbsgroup>
-	  <caption>
-	    Zooming in on our characters' face.
-	  </caption>
 	</figure>
 	</li>
 
@@ -1517,6 +1517,9 @@
       </p>
       
 	<figure xml:id="fig-animate-shadow">
+	  <caption>
+	    Casting a shadow.
+	  </caption>
 	  <sbsgroup widths="40% 40%">
 	    <sidebyside>
 	      <image>
@@ -1592,9 +1595,6 @@
               </image>
 	    </sidebyside>
 	  </sbsgroup>
-	  <caption>
-	    Casting a shadow.
-	  </caption>
 	</figure>
 	</li>
 
@@ -1919,6 +1919,9 @@
           right.
         </p>
         <figure xml:id="diagram-unit-square-transformed">
+          <caption>The unit square, which appears on the left, is
+          transformed into the parallelogram shown on the right.
+          </caption>
           <sidebyside widths="40% 40%">
             <image>
               <prefigure xmlns="https://prefigure.org"
@@ -1968,9 +1971,6 @@
               </description>
             </image>      
           </sidebyside>
-          <caption>The unit square, which appears on the left, is
-          transformed into the parallelogram shown on the right.
-          </caption>
         </figure>
       </introduction>
 

--- a/src/section3-2.xml
+++ b/src/section3-2.xml
@@ -26,6 +26,9 @@
     </p>
 
     <figure xml:id="fig-city-map">
+      <caption>
+	A city map.
+      </caption>
       <image width="45%">
         <shortdescription>
           Street map of a city
@@ -45,9 +48,6 @@
           <xi:include href="prefigure/section3-2/city-map.xml"/>
         </prefigure>
       </image>
-      <caption>
-	A city map.
-      </caption>
     </figure>
 
     <p> In this section, we will develop the concept of a
@@ -69,6 +69,9 @@
         </p>
 
         <figure xml:id="fig-basis-1">
+	  <caption>
+	    Linear combinations of <m>\vvec_1</m> and <m>\vvec_2</m>.
+	  </caption>
 	  <image width="50%">
             <shortdescription>
               Two vectors and a set of skewed grid lines
@@ -92,9 +95,6 @@
               <xi:include href="prefigure/section3-2/basis-1.xml"/>
             </prefigure>
           </image>
-	  <caption>
-	    Linear combinations of <m>\vvec_1</m> and <m>\vvec_2</m>.
-	  </caption>
         </figure>
       </introduction>
 
@@ -895,6 +895,9 @@
 	</p>
 
 	<figure xml:id="fig-basis-revenue-elements">
+	  <caption> A representation of the basis elements of
+	  <m>\bcal</m>.
+	  </caption>
 	  <sbsgroup widths="40% 40%%">
             <sidebyside>
 	      <image>
@@ -956,9 +959,6 @@
               </image>
 	    </sidebyside>
           </sbsgroup>
-	  <caption> A representation of the basis elements of
-	  <m>\bcal</m>.
-	  </caption>
 	</figure>
 
 	<p>
@@ -1141,6 +1141,9 @@
       </p>
 
       <figure xml:id = "fig-edge-detection">
+	<caption> A canyon wall in Capitol Reef National Park and the
+	result of an edge detection algorithm.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image source="images/spring-canyon-cropped.jpg">
             <shortdescription>
@@ -1174,9 +1177,6 @@
             </description>
           </image>
 	</sidebyside>
-	<caption> A canyon wall in Capitol Reef National Park and the
-	result of an edge detection algorithm.
-	</caption>
       </figure>
 
       <p> We will consider a very simple version of an edge detection

--- a/src/section3-3.xml
+++ b/src/section3-3.xml
@@ -17,6 +17,10 @@
     </p>
 
     <figure xml:id="fig-jpeg-orig">
+      <caption>
+	An image stored as a <m>1440\times1468</m> array of pixels
+	along with a close-up of a smaller <m>8\times8</m> array.
+      </caption>
       <sidebyside widths="45% 45%">
 	<image source="images/spring-canyon-cropped.jpg">
           <shortdescription>
@@ -48,10 +52,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	An image stored as a <m>1440\times1468</m> array of pixels
-	along with a close-up of a smaller <m>8\times8</m> array.
-      </caption>
     </figure>
     
     <p> A lot of data is required to display this image.  A quantity
@@ -621,6 +621,9 @@
     </p>
 
     <figure xml:id="fig-jpeg-luminance">
+      <caption>
+	The original image rendered with only the luminance values.
+      </caption>
       <sidebyside widths="48% 48%">
 	<image source="images/spring-canyon-cropped.jpg">
           <shortdescription>
@@ -647,9 +650,6 @@
           </description>
         </image>
       </sidebyside>
-      <caption>
-	The original image rendered with only the luminance values.
-      </caption>
     </figure>
 
     <p> For comparison, shown in <xref ref="fig-jpeg-chrominance" />
@@ -658,6 +658,10 @@
     visual detail is considerably less in these images.</p>
     
     <figure xml:id="fig-jpeg-chrominance">
+      <caption>
+	The original image rendered, on the left, with only blue
+	chrominance and, on the right, with only red chrominance.
+      </caption>
       <sidebyside widths="48% 48%">
 	<image source="images/spring-canyon-blue-chrominance.jpg">
           <shortdescription>
@@ -682,10 +686,6 @@
           </description>
         </image>
       </sidebyside>
-      <caption>
-	The original image rendered, on the left, with only blue
-	chrominance and, on the right, with only red chrominance.
-      </caption>
     </figure>
 
     <p> The aim of the JPEG compression algorithm is to represent an
@@ -713,6 +713,11 @@
     </p>
     
     <figure xml:id="fig-jpeg-block">
+      <caption>
+	An <m>8\times8</m> block of pixels outlined in green in the
+	original image on the left.  We see the same block on a smaller
+	scale on the right.
+      </caption>
       <sidebyside widths="48% 48%">
 	<image source="images/jpeg-block.jpg">
           <shortdescription>
@@ -738,11 +743,6 @@
           </description>
         </image>
       </sidebyside>
-      <caption>
-	An <m>8\times8</m> block of pixels outlined in green in the
-	original image on the left.  We see the same block on a smaller
-	scale on the right.
-      </caption>
     </figure>
 
     <p> Notice that this block, as seen in the original image, is very
@@ -751,6 +751,8 @@
     </p>
 
     <figure xml:id="fig-jpeg-block-zoom">
+      <caption> The <m>8\times8</m> block under consideration.
+      </caption>
       <sidebyside widths="45% 45%">
 	<p> Here we see a close-up of the block.  The important point
 	here is that the colors do not change too much over this
@@ -773,8 +775,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption> The <m>8\times8</m> block under consideration.
-      </caption>
     </figure>
 
     <p> Following our earlier work, we will change the representation
@@ -787,6 +787,9 @@
     </p>
     
     <figure xml:id="fig-jpeg-block-luminance">
+      <caption>
+	The luminance values in this block.
+      </caption>
       <sidebyside widths="48% 48%">
 	<image>
           <shortdescription>
@@ -822,9 +825,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	The luminance values in this block.
-      </caption>
     </figure>
 
     <p> Our strategy in the compression algorithm is to perform a
@@ -898,6 +898,10 @@
     </p>
 
     <figure xml:id="fig-jpeg-fourier-basis">
+      <caption>
+	Four of the basis vectors <m>\vvec_0</m>, <m>\vvec_1</m>,
+	<m>\vvec_2</m>, and <m>\vvec_7</m>.
+      </caption>
       <sbsgroup widths="45% 45%">
         <sidebyside>
 	  <image>
@@ -976,10 +980,6 @@
           </image>
         </sidebyside>
       </sbsgroup>
-      <caption>
-	Four of the basis vectors <m>\vvec_0</m>, <m>\vvec_1</m>,
-	<m>\vvec_2</m>, and <m>\vvec_7</m>.
-      </caption>
     </figure>
 
     <sidebyside widths="45% 50%">
@@ -1506,6 +1506,10 @@ print (y_fourier.numerical_approx(digits=3))
     </p>
 
     <figure xml:id="fig-jpeg-quality">
+      <caption>
+	When creating a JPEG file, we choose a value of the <q>quality</q>
+	parameter. 
+      </caption>
       <sidebyside width="40%">
 	<image source="images/quality.jpg">
           <shortdescription>
@@ -1520,10 +1524,6 @@ print (y_fourier.numerical_approx(digits=3))
           </description>
         </image>
       </sidebyside>
-      <caption>
-	When creating a JPEG file, we choose a value of the <q>quality</q>
-	parameter. 
-      </caption>
     </figure>
 
     <p> To see how this works, suppose the quality setting is
@@ -1620,6 +1620,10 @@ image.
     </p>
 
     <figure xml:id="fig-jpeg-image-low">
+      <caption>
+	The original image and the result of storing the image with a
+	low quality setting.
+      </caption>
       <sidebyside widths="48% 48%">
 	<image source="images/spring-canyon-cropped.jpg">
           <shortdescription>
@@ -1644,10 +1648,6 @@ image.
           </description>
         </image>
       </sidebyside>
-      <caption>
-	The original image and the result of storing the image with a
-	low quality setting.
-      </caption>
     </figure>
 
     <p> This discussion of the JPEG compression algorithm is meant to

--- a/src/section3-4.xml
+++ b/src/section3-4.xml
@@ -22,6 +22,10 @@
     </p>
 
     <figure xml:id="fig-intro-dets">
+      <caption>
+	Linear combinations of two vectors <m>\vvec_1</m> and <m>\vvec_2</m> 
+	form a collection of congruent parallelograms.
+      </caption>
       <image width="50%">
         <shortdescription>
           Two vectors and the grid of linear combinations they define.
@@ -37,10 +41,6 @@
           <xi:include href="prefigure/section3-2/basis-1.xml"/>
         </prefigure>
       </image>
-      <caption>
-	Linear combinations of two vectors <m>\vvec_1</m> and <m>\vvec_2</m> 
-	form a collection of congruent parallelograms.
-      </caption>
     </figure>
 
     <p> Notice how the linear combinations form a set of congruent
@@ -260,6 +260,10 @@
     </p>
 
     <figure xml:id="fig-det-orientation">
+      <caption>
+	The vectors on the left are positively oriented while the ones
+	on the right are negatively oriented.
+      </caption>
       <sidebyside widths="30% 30%">
 	<image>
           <shortdescription>
@@ -297,10 +301,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	The vectors on the left are positively oriented while the ones
-	on the right are negatively oriented.
-      </caption>
     </figure>
 
     <definition>
@@ -335,6 +335,11 @@
 	</p>
 
 	<figure xml:id="fig-det-identity">
+	  <caption>
+	    The determinant <m>\det(I) = 1</m>, as seen on the left.
+	    On the right, we see that <m>\det(A) = -2</m>
+	    where <m>A</m> is the matrix whose columns are shown.
+	  </caption>
 	  <sidebyside widths="40% 40%">
 	    <image>
               <shortdescription>
@@ -370,11 +375,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    The determinant <m>\det(I) = 1</m>, as seen on the left.
-	    On the right, we see that <m>\det(A) = -2</m>
-	    where <m>A</m> is the matrix whose columns are shown.
-	  </caption>
 	</figure>
 
 	<p> Now consider the matrix
@@ -617,6 +617,9 @@
       </p>
 
       <figure xml:id="fig-parallelogram-f">
+	<caption> The determinant of a triangular matrix equals the
+	product of its diagonal entries.
+	</caption>
 	<sidebyside widths="30% 30%">
 	  <image>
             <shortdescription>
@@ -647,9 +650,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption> The determinant of a triangular matrix equals the
-	product of its diagonal entries.
-	</caption>
       </figure>
       </li>
 

--- a/src/section4-1.xml
+++ b/src/section4-1.xml
@@ -424,6 +424,11 @@
     </p>
 
     <figure xml:id="fig-eigen-intro">
+      <caption>
+	On the left, the vector <m>\vvec</m> is not an eigenvector.
+	On the right, the vector <m>\vvec</m> is an eigenvector with
+	eigenvalue <m>\lambda = 3</m>.
+      </caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shortdescription>
@@ -457,11 +462,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	On the left, the vector <m>\vvec</m> is not an eigenvector.
-	On the right, the vector <m>\vvec</m> is an eigenvector with
-	eigenvalue <m>\lambda = 3</m>.
-      </caption>
     </figure>
 
     <p> It is not difficult to see that any multiple of
@@ -476,6 +476,10 @@
     </p>
 
     <figure xml:id="fig-eigen-intro-2">
+      <caption>
+	Here we see another eigenvector <m>\vvec</m> with eigenvalue
+	<m>\lambda = -1</m>.
+      </caption>
       <sidebyside width="45%">
 	<image>
           <shortdescription>
@@ -494,10 +498,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	Here we see another eigenvector <m>\vvec</m> with eigenvalue
-	<m>\lambda = -1</m>.
-      </caption>
     </figure>
 
     <p> The interactive diagram we used in the activity is meant to
@@ -591,6 +591,10 @@
     </p>
 
     <figure xml:id="fig-eigen-intro-diagonal">
+      <caption> The diagonal matrix <m>D</m> stretches vectors
+      horizontally by a factor of <m>3</m> and flips vectors
+      vertically. 
+      </caption>
       <sidebyside widths="40% 40%">
 	<image>
           <shortdescription>
@@ -624,10 +628,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption> The diagonal matrix <m>D</m> stretches vectors
-      horizontally by a factor of <m>3</m> and flips vectors
-      vertically. 
-      </caption>
     </figure>
 
     <p> The matrix
@@ -642,6 +642,10 @@
     </p>
     
     <figure xml:id="fig-eigen-intro-A">
+      <caption> The matrix <m>A</m> has the same geometric effect as
+      the diagonal matrix <m>D</m> when expressed in the
+      coordinate system defined by the basis of eigenvectors.  
+      </caption>
       <sidebyside widths="40% 40%">
 	<image>
           <shortdescription>
@@ -682,10 +686,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption> The matrix <m>A</m> has the same geometric effect as
-      the diagonal matrix <m>D</m> when expressed in the
-      coordinate system defined by the basis of eigenvectors.  
-      </caption>
     </figure>
 
     <p> In a sense that will be made precise later, having a set of

--- a/src/section4-3.xml
+++ b/src/section4-3.xml
@@ -34,6 +34,10 @@
     </p>
     
     <figure xml:id="fig-eigen-diag-A">
+      <caption> The matrix <m>A</m> has the same geometric effect as
+      the diagonal matrix <m>D</m> when viewed in
+      the basis of eigenvectors.  
+      </caption>
       <sidebyside widths="40% 40%">
 	<image>
           <shortdescription>
@@ -74,10 +78,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption> The matrix <m>A</m> has the same geometric effect as
-      the diagonal matrix <m>D</m> when viewed in
-      the basis of eigenvectors.  
-      </caption>
     </figure>
 
     <p>

--- a/src/section4-4.xml
+++ b/src/section4-4.xml
@@ -488,6 +488,10 @@
     </p>
 
     <figure xml:id="fig-eigen-dynam-saddle">
+      <caption> The trajectories of the dynamical system formed by the
+      matrix <m>A</m> in the coordinate system defined by
+      <m>\bcal</m>, on the left,
+      and in the standard coordinate system, on the right.</caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shotdescription>
@@ -540,10 +544,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption> The trajectories of the dynamical system formed by the
-      matrix <m>A</m> in the coordinate system defined by
-      <m>\bcal</m>, on the left,
-      and in the standard coordinate system, on the right.</caption>
     </figure>
 
     <p> We conclude that, regardless of the initial populations, the
@@ -994,6 +994,9 @@
       ref="fig-eigen-phase-repellor" />. </p>
 
       <figure xml:id="fig-eigen-phase-repellor">
+	<caption> The origin is a repellor when <m>|\lambda_1|,
+	|\lambda_2| \gt 1</m>.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image>
             <shortdescription>
@@ -1041,9 +1044,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption> The origin is a repellor when <m>|\lambda_1|,
-	|\lambda_2| \gt 1</m>.
-	</caption>
       </figure>
       </li>
 
@@ -1057,6 +1057,9 @@
       ref="fig-eigen-phase-saddle" />.  </p>
 
       <figure xml:id="fig-eigen-phase-saddle">
+	<caption> The origin is a saddle when <m>|\lambda_1|\gt 1 \gt
+	|\lambda_2|</m>.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image>
             <shortdescription>
@@ -1103,9 +1106,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption> The origin is a saddle when <m>|\lambda_1|\gt 1 \gt
-	|\lambda_2|</m>.
-	</caption>
       </figure>
       </li>
 
@@ -1118,6 +1118,9 @@
       ref="fig-eigen-phase-attractor" />. </p>
 
       <figure xml:id="fig-eigen-phase-attractor">
+	<caption> The origin is an attractor when <m>|\lambda_1|,
+	|\lambda_2| \lt 1</m>.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image>
             <shortdescription>
@@ -1162,9 +1165,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption> The origin is an attractor when <m>|\lambda_1|,
-	|\lambda_2| \lt 1</m>.
-	</caption>
       </figure>
       </li>
 
@@ -1176,6 +1176,9 @@
       />. </p>
 
       <figure xml:id="fig-eigen-phase-spiralr">
+	<caption> The origin is a spiral repellor when <m>A</m> has an
+	eigenvalue <m>\lambda=a+bi</m> with <m>a^2+b^2\gt 1</m>.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image>
             <shortdescription>
@@ -1220,9 +1223,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption> The origin is a spiral repellor when <m>A</m> has an
-	eigenvalue <m>\lambda=a+bi</m> with <m>a^2+b^2\gt 1</m>.
-	</caption>
       </figure>
       </li>
 
@@ -1234,6 +1234,9 @@
       />. </p>
 
       <figure xml:id="fig-eigen-phase-center">
+	<caption> The origin is a center when <m>A</m> has an
+	eigenvalue <m>\lambda=a+bi</m> with <m>a^2+b^2 = 1</m>.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image>
             <shortdescription>
@@ -1277,9 +1280,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption> The origin is a center when <m>A</m> has an
-	eigenvalue <m>\lambda=a+bi</m> with <m>a^2+b^2 = 1</m>.
-	</caption>
       </figure>
       </li>
 
@@ -1291,6 +1291,9 @@
       />. </p>
 
       <figure xml:id="fig-eigen-phase-spirala">
+	<caption> The origin is a spiral attractor when <m>A</m> has an
+	eigenvalue <m>\lambda=a+bi</m> with <m>a^2+b^2\lt 1</m>.
+	</caption>
 	<sidebyside widths="45% 45%">
 	  <image>
             <shortdescription>
@@ -1333,9 +1336,6 @@
             </prefigure>
           </image>
 	</sidebyside>
-	<caption> The origin is a spiral attractor when <m>A</m> has an
-	eigenvalue <m>\lambda=a+bi</m> with <m>a^2+b^2\lt 1</m>.
-	</caption>
       </figure>
       </li>
 
@@ -1520,6 +1520,12 @@
     </p>
 
     <figure xml:id="fig-eigen-3d-saddle">
+      <caption>
+	In a <m>3\times3</m> system with <m>\lambda_1 = 0.6</m>,
+	<m>\lambda_2=0.8</m>, and <m>\lambda_3 = 1.1</m>, the
+	trajectories <m>\coords{\xvec_k}{\bcal}</m> move along the
+	curves shown above.   
+      </caption>
       <sidebyside widths="48% 48%">
 	<image>
           <shortdescription>
@@ -1561,12 +1567,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	In a <m>3\times3</m> system with <m>\lambda_1 = 0.6</m>,
-	<m>\lambda_2=0.8</m>, and <m>\lambda_3 = 1.1</m>, the
-	trajectories <m>\coords{\xvec_k}{\bcal}</m> move along the
-	curves shown above.   
-      </caption>
     </figure>
 
     <p> In the same way, suppose we have a <m>3\times3</m> system with
@@ -1580,6 +1580,13 @@
     eigenspace <m>E_{1.1}</m>. </p>
 
     <figure xml:id="fig-eigen-3d-spiral">
+      <caption>
+	In a <m>3\times3</m> system with complex eigenvalues
+	<m>\lambda = a\pm bi</m> with <m>|\lambda| \lt 1</m> and
+	<m>\lambda_3=1.1</m>, the trajectories
+	<m>\coords{\xvec_k}{\bcal}</m> move along the curves
+	shown above.
+      </caption>
       <sidebyside widths="48% 48%">
 	<image>
           <shortdescription>
@@ -1621,13 +1628,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	In a <m>3\times3</m> system with complex eigenvalues
-	<m>\lambda = a\pm bi</m> with <m>|\lambda| \lt 1</m> and
-	<m>\lambda_3=1.1</m>, the trajectories
-	<m>\coords{\xvec_k}{\bcal}</m> move along the curves
-	shown above.
-      </caption>
     </figure>
 
     <activity>

--- a/src/section4-5.xml
+++ b/src/section4-5.xml
@@ -851,6 +851,7 @@ markov_chain(C, x0, 10)
 	instance, page 1 links to both pages 2 and 3, but page 2 only
 	links to page 1.</p>
 	<figure xml:id="fig-google-intro">
+	  <caption> Our first Internet. </caption>
 	  <image>
             <shortdescription>
               A model of an Internet with three web pages.
@@ -871,7 +872,6 @@ markov_chain(C, x0, 10)
               <xi:include href="prefigure/section4-5/google-intro.xml"/>
             </prefigure>
           </image>
-	  <caption> Our first Internet. </caption>
 	</figure>
       </sidebyside>
 
@@ -1040,6 +1040,9 @@ markov_chain(G, x0, 20)
       ref="fig-google-irreducible" />. </p>
 
       <figure xml:id="fig-google-irreducible">
+	<caption>
+	  A simple model of the Internet with eight web pages. 
+	</caption>
 	<image width="90%">
           <shortdescription>
             A model of an Internet with eight web pages
@@ -1058,9 +1061,6 @@ markov_chain(G, x0, 20)
             <xi:include href="prefigure/section4-5/google-irreducible.xml"/>
           </prefigure>
         </image>
-	<caption>
-	  A simple model of the Internet with eight web pages. 
-	</caption>
       </figure>
       
       <p>
@@ -1090,6 +1090,9 @@ markov_chain(G, x0, 20)
 	  <xref ref="fig-google-cyclic" />. </p>
 
 	  <figure xml:id="fig-google-cyclic">
+	    <caption>
+	      A model of the Internet with five web pages. 
+	    </caption>
 	    <image width="50%">
               <shortdescription>
                 Model of an Internet with five web pages.
@@ -1105,9 +1108,6 @@ markov_chain(G, x0, 20)
                 <xi:include href="prefigure/section4-5/google-cyclic.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      A model of the Internet with five web pages. 
-	    </caption>
 	  </figure>	    
 
 	  <p> What happens when you begin the Markov chain with the
@@ -1123,6 +1123,9 @@ markov_chain(G, x0, 20)
 	  shown in <xref ref="fig-google-reducible" />. </p>
 
 	  <figure xml:id="fig-google-reducible">
+	    <caption>
+	      Another model of the Internet with eight web pages. 
+	    </caption>
 	    <image width="90%">
               <shortdescription>
                 Another model Internet with eight pages.
@@ -1145,9 +1148,6 @@ markov_chain(G, x0, 20)
                 <xi:include href="prefigure/section4-5/google-reducible.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      Another model of the Internet with eight web pages. 
-	    </caption>
 	  </figure>
 
 	  <p> Notice that this version of the Internet is identical to
@@ -1263,6 +1263,10 @@ markov_chain(G, x0, 20)
     matrix. </p>
 
     <figure xml:id="fig-google-reducible-box">
+      <caption>
+	The pages outside the box give up all of their PageRank to the
+	pages inside the box.
+      </caption>
       <image width="80%">
         <shortdescription>
           The previous Internet with eight pages and a box drawn
@@ -1282,10 +1286,6 @@ markov_chain(G, x0, 20)
           <xi:include href="prefigure/section4-5/google-reducible-box.xml"/>
         </prefigure>
       </image>
-      <caption>
-	The pages outside the box give up all of their PageRank to the
-	pages inside the box.
-      </caption>
     </figure>
 
     <p> Google solves this problem by slightly modifying the Google

--- a/src/section5-2.xml
+++ b/src/section5-2.xml
@@ -674,6 +674,8 @@ inverse_power(A, x0, 20)
 	shaded in <xref ref="fig-numerical-power-line" />. </p>
 
 	<figure xml:id="fig-numerical-power-line">
+	  <caption> The range of eigenvalues of <m>A</m>.
+	  </caption>
 	  <image width="75%">
             <shortdescription>
               A number line with regions indicated in which the other
@@ -696,8 +698,6 @@ inverse_power(A, x0, 20)
               <xi:include href="prefigure/section5-2/numerical-power-line.xml"/>
             </prefigure>
           </image>
-	  <caption> The range of eigenvalues of <m>A</m>.
-	  </caption>
 	</figure>
 
 	<p> The Sage cell below has a function

--- a/src/section6-1.xml
+++ b/src/section6-1.xml
@@ -43,6 +43,9 @@
 	  use the Pythagorean theorem to find the length of
           <m>\vvec</m>.</p>
 	  <figure>
+	    <caption>
+	      Sketch the vector <m>\vvec</m> and find its length.
+	    </caption>
 	    <sidebyside width="50%">
 	      <image>
                 <shortdescription>
@@ -59,9 +62,6 @@
                 </prefigure>
               </image>
 	    </sidebyside>
-	    <caption>
-	      Sketch the vector <m>\vvec</m> and find its length.
-	    </caption>
 	  </figure>
         </statement>
         <response component="rs-preview"/>
@@ -270,6 +270,8 @@
     </p>
 
     <figure xml:id="fig-dot-length">
+      <caption> The vector <m>\vvec=\twovec32</m>.
+      </caption>
       <image width="50%">
         <shortdescription>
           A two dimensional vector against a coordinate grid and set
@@ -291,8 +293,6 @@
           <xi:include href="prefigure/section6-1/dot-length.xml"/>
         </prefigure>
         </image>
-      <caption> The vector <m>\vvec=\twovec32</m>.
-      </caption>
     </figure>
 
     <p>
@@ -316,6 +316,10 @@
     </p>
 
     <figure xml:id="fig-dot-angle">
+      <caption>
+	The dot product <m>\vvec\cdot\wvec</m> measures the angle  
+	<m>\theta</m>.
+      </caption>
       <image width="50%">
         <shortdescription>
           Two vectors, the angle between them, and their vector difference.
@@ -333,10 +337,6 @@
           <xi:include href="prefigure/section6-1/dot-angle.xml"/>
         </prefigure>
       </image>
-      <caption>
-	The dot product <m>\vvec\cdot\wvec</m> measures the angle  
-	<m>\theta</m>.
-      </caption>
     </figure>
 
     <p> To see this, we will apply the Law of Cosines, which says that
@@ -390,6 +390,9 @@
 	      </p>
 	
 	      <figure xml:id="fig-dot-empty">
+		<caption>
+		  Sketch the vectors <m>\vvec</m> and <m>\wvec</m> here.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A coordinate grid and set of axes.
@@ -406,9 +409,6 @@
                         href="prefigure/section1-1/empty-4.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  Sketch the vectors <m>\vvec</m> and <m>\wvec</m> here.
-		</caption>
 	      </figure>
 	    </li>
 	    
@@ -629,6 +629,9 @@
     </p>
 
     <figure xml:id="fig-similar-vectors">
+      <caption>
+	Which of the vectors are most similar?
+      </caption>
       <image width="50%">
         <shortdescription>
           Three two dimensional vectors two of which nearly point in
@@ -648,9 +651,6 @@
               href="prefigure/section6-1/similar-vectors.xml"/>
         </prefigure>
       </image>
-      <caption>
-	Which of the vectors are most similar?
-      </caption>
     </figure>
 
     <activity>
@@ -822,6 +822,11 @@ series_plot(ds1, 'blue') + series_plot(ds2, 'orange')
 		  </p>
 
 		  <figure xml:id="fig-correlation">
+		    <caption>
+		      On the left, the demeaned time series are positive
+		      scalar multiples of one another.  On the right,
+		      they are negative scalar multiples.
+		    </caption>
 		    <sidebyside widths="40% 40%">
 		      <image>
                         <shortdescription>
@@ -871,11 +876,6 @@ series_plot(ds1, 'blue') + series_plot(ds2, 'orange')
                         </prefigure>
                       </image>
 		    </sidebyside>
-		    <caption>
-		      On the left, the demeaned time series are positive
-		      scalar multiples of one another.  On the right,
-		      they are negative scalar multiples.
-		    </caption>
 		  </figure>
 
 		  <p>
@@ -1111,6 +1111,9 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
     </p>
 
     <figure xml:id="fig-clusters">
+      <caption>
+	A set of 177 data points.
+      </caption>
       <image width="80%">
         <shortdescription>
           A scatter plot of 177 data points.
@@ -1127,9 +1130,6 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
           <xi:include href="prefigure/section6-1/cluster-plot.xml"/>
         </prefigure>
       </image>
-      <caption>
-	A set of 177 data points.
-      </caption>
     </figure>
 
     <p>
@@ -1192,6 +1192,10 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
 	      </p>
 
 	      <figure xml:id="fig-centroid-plot">
+		<caption>
+		  The vectors <m>\vvec_1</m>, <m>\vvec_2</m>,
+		  <m>\vvec_3</m> and their centroid.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A coordinate grid and set of coordinate axes.
@@ -1207,10 +1211,6 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
                     <xi:include href="prefigure/section6-1/empty-5-k.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  The vectors <m>\vvec_1</m>, <m>\vvec_2</m>,
-		  <m>\vvec_3</m> and their centroid.
-		</caption>
 	      </figure>
 
 	      <p>
@@ -1235,6 +1235,10 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
 	      </p>
 
 	      <figure xml:id="fig-clustering-ex">
+		<caption>
+		  We will group this set of four points into two
+		  clusters.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A scatter plot of four data points.
@@ -1252,10 +1256,6 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
                     <xi:include href="prefigure/section6-1/kmeans-data.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  We will group this set of four points into two
-		  clusters.
-		</caption>
 	      </figure>
 
 	      <p> 
@@ -1302,6 +1302,9 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
 	      </p>
 
 	      <figure xml:id="fig-clustering-ex-2">
+		<caption>
+		  Indicate the new centroids and clusters.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A scatter plot of four data points.
@@ -1320,9 +1323,6 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
                   </prefigure>
                   
                 </image>
-		<caption>
-		  Indicate the new centroids and clusters.
-		</caption>
 	      </figure>
 
 	      <p>
@@ -1344,6 +1344,9 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
 	      </p>
 
 	      <figure xml:id="fig-clustering-ex-3">
+		<caption>
+		  Indicate the new centroids and clusters.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A scatter plot of four data points.
@@ -1361,9 +1364,6 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
                     <xi:include href="prefigure/section6-1/kmeans-data.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  Indicate the new centroids and clusters.
-		</caption>
 	      </figure>
 
 	      <p>
@@ -1676,6 +1676,10 @@ plotclusters(clusters, centroids)
 	      </p>
 	      
 	      <figure xml:id="fig-clustering-elbow">
+		<caption>
+		  Construct a plot of the minimal objective as it
+		  depends on the choice of <m>k</m>.
+		</caption>
 		<image width="80%">
                   <shortdescription>
                     A horizontal axis labelled k and a vertical axis
@@ -1695,10 +1699,6 @@ plotclusters(clusters, centroids)
                     <xi:include href="prefigure/section6-1/clustering-elbow.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  Construct a plot of the minimal objective as it
-		  depends on the choice of <m>k</m>.
-		</caption>
 	      </figure>
 
 	      <p>

--- a/src/section6-2.xml
+++ b/src/section6-2.xml
@@ -34,6 +34,10 @@
           <p component="rs-preview">You can upload a scan of your
           sketch below.</p>
 	  <figure xml:id="fig-pa-6-2">
+	    <caption>
+	      Sketch the vector <m>\vvec</m> and one vector
+	      orthogonal to it.
+	    </caption>
 	    <image width="50%">
               <shortdescription>
                 A coordinate grid and set of axes.
@@ -48,10 +52,6 @@
                 <xi:include href="prefigure/section1-1/empty-4.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      Sketch the vector <m>\vvec</m> and one vector
-	      orthogonal to it.
-	    </caption>
 	  </figure>
         </statement>
         <response component="rs-preview"/>
@@ -190,6 +190,11 @@
     </p>
 
     <figure xml:id="fig-orthog-comps">
+      <caption>
+	On the left is a line <m>L</m> and its orthogonal complement
+	<m>L^\perp</m>.  On the right is a plane <m>W</m> and its
+	orthogonal complement <m>W^\perp</m> in <m>\real^3</m>.
+      </caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shortdescription>
@@ -221,11 +226,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	On the left is a line <m>L</m> and its orthogonal complement
-	<m>L^\perp</m>.  On the right is a plane <m>W</m> and its
-	orthogonal complement <m>W^\perp</m> in <m>\real^3</m>.
-      </caption>
     </figure>
 
     <p>
@@ -885,6 +885,10 @@
     </proposition>
  	
     <figure xml:id="fig-orthog-comp">
+      <caption>
+	The orthogonal complement of the column space of <m>A</m> is
+	the null space of <m>A^T</m>.
+      </caption>
       <image width="45%">
         <shortdescription>
           The column space of a matrix and the null space of its
@@ -903,10 +907,6 @@
           <xi:include href="prefigure/section6-2/nul-at.xml"/>
         </prefigure>
       </image>
-      <caption>
-	The orthogonal complement of the column space of <m>A</m> is
-	the null space of <m>A^T</m>.
-      </caption>
     </figure>
 	
 

--- a/src/section6-3.xml
+++ b/src/section6-3.xml
@@ -621,6 +621,11 @@
     </p>
 
     <figure xml:id="fig-3d-orthog-proj">
+      <caption>
+	Given a plane in <m>\real^3</m> and a vector <m>\bvec</m> not
+	in the plane, we wish to find the vector <m>\bhat</m> in the
+	plane that is closest to <m>\bvec</m>.
+      </caption>
       <image width="55%">
         <shortdescription>
           A plane in three dimensions, a vector not in the plane,
@@ -639,11 +644,6 @@
           <xi:include href="prefigure/section6-3/3d-orthog-proj-3.xml"/>
         </prefigure>
       </image>
-      <caption>
-	Given a plane in <m>\real^3</m> and a vector <m>\bvec</m> not
-	in the plane, we wish to find the vector <m>\bhat</m> in the
-	plane that is closest to <m>\bvec</m>.
-      </caption>
     </figure>
 
     <p>
@@ -657,6 +657,11 @@
     </p>
 
     <figure xml:id="fig-projection-line-a">
+      <caption>
+	Given a line <m>L</m> and a vector <m>\bvec</m>, we seek the
+	vector <m>\bhat</m> on <m>L</m> that is closest to
+	<m>\bvec</m>.  
+      </caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shortdescription>
@@ -691,11 +696,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	Given a line <m>L</m> and a vector <m>\bvec</m>, we seek the
-	vector <m>\bhat</m> on <m>L</m> that is closest to
-	<m>\bvec</m>.  
-      </caption>
     </figure>
 
     <p>
@@ -714,6 +714,11 @@
     </p>
 
     <figure xml:id="fig-projection-line-b">
+      <caption>
+	The vector <m>\bhat</m> is closer to <m>\bvec</m> than
+	<m>\yvec</m> because <m>\bvec-\bhat</m> is orthogonal to
+	<m>L</m>. 
+      </caption>
       <image width="50%">
         <shortdescription>
           A two dimensional diagram demonstrating how orthogonality
@@ -737,11 +742,6 @@
           <xi:include href="prefigure/section6-3/projection-line-3.xml"/>
         </prefigure>
       </image>
-      <caption>
-	The vector <m>\bhat</m> is closer to <m>\bvec</m> than
-	<m>\yvec</m> because <m>\bvec-\bhat</m> is orthogonal to
-	<m>L</m>. 
-      </caption>
     </figure>
 
     <definition>
@@ -773,6 +773,10 @@
 	      </p>
 	      
 	      <figure xml:id="fig-projection-line-c">
+		<caption>
+		  Finding the orthogonal projection of <m>\bvec</m> onto
+		  the line defined by <m>\wvec</m>.
+		</caption>
                 <sidebyside widths="45% 45%">
 		  <image>
                     <shortdescription>
@@ -817,10 +821,6 @@
                     </prefigure>
                   </image>
 		</sidebyside>
-		<caption>
-		  Finding the orthogonal projection of <m>\bvec</m> onto
-		  the line defined by <m>\wvec</m>.
-		</caption>
 	      </figure>
 
 	      <p>
@@ -881,6 +881,12 @@
 	      </p>
 	      
 	      <figure xml:id="fig-3d-orthog">
+		<caption>
+		  Given a plane <m>W</m> defined by the orthogonal vectors
+		  <m>\wvec_1</m> and <m>\wvec_2</m> and another vector
+		  <m>\bvec</m>, we seek the vector <m>\bhat</m> on <m>W</m>
+		  closest to <m>\bvec</m>.
+		</caption>
                 <image width="55%">
                   <shortdescription>
                     Finding the orthogonal projection in three
@@ -901,12 +907,6 @@
                     <xi:include href="prefigure/section6-3/3d-orthog-proj-2.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  Given a plane <m>W</m> defined by the orthogonal vectors
-		  <m>\wvec_1</m> and <m>\wvec_2</m> and another vector
-		  <m>\bvec</m>, we seek the vector <m>\bhat</m> on <m>W</m>
-		  closest to <m>\bvec</m>.
-		</caption>
 	      </figure>
 
 	      <p>
@@ -1695,6 +1695,12 @@
     </proposition>
 
     <figure xml:id="fig-orthog-decomp">
+      <caption>
+	A vector <m>\bvec</m> along with <m>\bhat</m>, its orthogonal
+	projection onto the line <m>L</m>, and <m>\bvec^\perp</m>, its
+	orthogonal projection onto the orthogonal complement
+	<m>L^\perp</m>.
+      </caption>
       <image width="45%">
         <shortdescription>
           A two dimensional vector orthogonally projected onto a
@@ -1714,12 +1720,6 @@
           <xi:include href="prefigure/section6-3/orthog-decomp.xml"/>
         </prefigure>
       </image>
-      <caption>
-	A vector <m>\bvec</m> along with <m>\bhat</m>, its orthogonal
-	projection onto the line <m>L</m>, and <m>\bvec^\perp</m>, its
-	orthogonal projection onto the orthogonal complement
-	<m>L^\perp</m>.
-      </caption>
     </figure>
     
     <p>

--- a/src/section6-4.xml
+++ b/src/section6-4.xml
@@ -50,6 +50,9 @@
 	  is not orthogonal.
         </p>
         <figure xml:id="fig-gs-intro">
+          <caption>
+	    A basis for <m>\real^2</m>.
+	  </caption>
 	  <image width="50%">
             <shortdescription>
               Two vectors in the two dimensional coordinate plane
@@ -65,9 +68,6 @@
               <xi:include href="prefigure/section6-4/gram-schmidt-intro.xml"/>
             </prefigure>
           </image>
-          <caption>
-	    A basis for <m>\real^2</m>.
-	  </caption>
         </figure>
       </introduction>
 
@@ -116,6 +116,9 @@
           <p component="rs-preview">You can upload a scan of your sketch below.</p>
 	  
 	  <figure xml:id="fig-gs-empty">
+	    <caption>
+	      Sketch the new basis <m>\wvec_1</m> and <m>\wvec_2</m>.
+	    </caption>
 	    <image width="50%">
               <shortdescription>
                 A two dimensional coordinate grid and set of axes.
@@ -130,9 +133,6 @@
                 <xi:include href="prefigure/section6-4/empty-3.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      Sketch the new basis <m>\wvec_1</m> and <m>\wvec_2</m>.
-	    </caption>
 	  </figure>
         </statement>
         <response component="rs-preview"/>
@@ -221,6 +221,11 @@
     </p>
     
     <figure xml:id="fig-proj-orthog">
+      <caption>
+	If <m>\bhat</m> is the orthogonal projection of <m>\bvec</m>
+	onto <m>W</m>, then <m>\bvec-\bhat</m> is orthogonal to
+	<m>W</m>. 
+      </caption>
       <image width="50%">
         <shortdescription>
           Orthogonally projecting a three dimensional vector onto a
@@ -239,11 +244,6 @@
           <xi:include href="prefigure/section6-3/3d-orthog-proj-2.xml"/>
         </prefigure>
       </image>
-      <caption>
-	If <m>\bhat</m> is the orthogonal projection of <m>\bvec</m>
-	onto <m>W</m>, then <m>\bvec-\bhat</m> is orthogonal to
-	<m>W</m>. 
-      </caption>
     </figure>
 
     <p>

--- a/src/section6-5.xml
+++ b/src/section6-5.xml
@@ -16,6 +16,10 @@
     </p>
     
     <figure xml:id="lst-squares-intro">
+      <caption>
+	A collection of points and a line approximating the
+	linear relationship implied by them.
+      </caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shortdescription>
@@ -46,10 +50,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	A collection of points and a line approximating the
-	linear relationship implied by them.
-      </caption>
     </figure>
 
     <p>
@@ -214,6 +214,7 @@
 		/>.  Are you able to draw a line that passes through
 		all three points? 
 		<figure xml:id="fig-ls-empty">
+		  <caption> Plot the three data points here. </caption>
 		  <image width="50%">
                     <shortdescription>
                       A two dimensional coordinate grid and set of
@@ -229,7 +230,6 @@
                       <xi:include href="prefigure/section6-5/empty-ls.xml"/>
                     </prefigure>
                   </image>
-		  <caption> Plot the three data points here. </caption>
 		</figure>
 	      </p>
 	    </li>
@@ -365,16 +365,16 @@
 		ref="fig-best-fit-line" />.
 	      </p>
 	      <figure xml:id="fig-best-fit-line">
+		<caption>
+		  The line that best approximates the three data
+		  points.
+		</caption>
 		<image width="50%">
                   <prefigure xmlns="https://prefigure.org"
                              label="pf-line-regress-2-sol">
                     <xi:include href="prefigure/section6-5/line-regress-2.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  The line that best approximates the three data
-		  points.
-		</caption>
 	      </figure>
 	    </li>
 	  </ol>
@@ -432,16 +432,16 @@
 		ref="fig-best-fit-line-ans" />.
 	      </p>
 	      <figure xml:id="fig-best-fit-line-ans">
+		<caption>
+		  The line that best approximates the three data
+		  points.
+		</caption>
 		<image width="50%">
                   <prefigure xmlns="https://prefigure.org"
                              label="pf-line-regress-2-ans">
                     <xi:include href="prefigure/section6-5/line-regress-2.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  The line that best approximates the three data
-		  points.
-		</caption>
 	      </figure>
 	    </li>
 	  </ol>
@@ -518,6 +518,10 @@
     </p>
 
     <figure xml:id="fig-least-squares-def">
+      <caption>
+	The solution of the least-squares problem and the vertical
+	distances between the line and the data points.
+      </caption>
       <image width="50%">
         <shortdescription>
           Three data points, the least squares line, and
@@ -536,10 +540,6 @@
           <xi:include href="prefigure/section6-5/line-regress-1.xml"/>
         </prefigure>
       </image>
-      <caption>
-	The solution of the least-squares problem and the vertical
-	distances between the line and the data points.
-      </caption>
     </figure>
   </subsection>
 
@@ -885,6 +885,10 @@ plot_model(xhat, data, domain=(12, 22))
     </p>
 
     <figure xml:id="fig-regression-scale">
+      <caption>
+	The lines appear to fit equally well in spite of the fact that
+	<m>\len{\bvec-A\xhat}^2</m> differs by a factor of 100.
+      </caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shortdescription>
@@ -924,10 +928,6 @@ plot_model(xhat, data, domain=(12, 22))
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	The lines appear to fit equally well in spite of the fact that
-	<m>\len{\bvec-A\xhat}^2</m> differs by a factor of 100.
-      </caption>
     </figure>
 
     <p>

--- a/src/section7-1.xml
+++ b/src/section7-1.xml
@@ -32,6 +32,10 @@
 	</p>
 
 	<figure xml:id="fig-preview-similar">
+	  <caption>
+	      Use these plots to sketch the vectors requested
+	      in the preview activity.
+	  </caption>
 	  <sidebyside widths="45% 45%">
 	    <image>
               <shortdescription>
@@ -62,10 +66,6 @@
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	      Use these plots to sketch the vectors requested
-	      in the preview activity.
-	  </caption>
 	</figure>
       </introduction>
 
@@ -291,6 +291,9 @@
     </p>
 
     <figure xml:id="fig-eigen-diag-D">
+      <caption>
+	  The matrix transformation defined by <m>D</m>.
+      </caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shortdescription>
@@ -328,9 +331,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	  The matrix transformation defined by <m>D</m>.
-      </caption>
     </figure>
 
     <p>
@@ -341,6 +341,9 @@
     </p>
 
     <figure xml:id="fig-eigen-diag-general">
+      <caption>
+	  The matrix transformation defined by <m>A</m>.
+      </caption>
       <sidebyside widths="45% 45%">
 	<image>
           <shortdescription>
@@ -381,9 +384,6 @@
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	  The matrix transformation defined by <m>A</m>.
-      </caption>
     </figure>
 
     <p>
@@ -866,6 +866,13 @@
 	</p>
 	  
 	<figure xml:id="fig-diag-factors">
+	  <caption>
+	    The transformation defined by <m>A=QDQ^T</m> can be
+	    interpreted as a sequence of geometric transformations:
+	    <m>Q^T</m> rotates by <m>-45^\circ</m>, <m>D</m>
+	    stretches and reflects, and <m>Q</m> rotates by
+	    <m>45^\circ</m>. 
+	  </caption>
           <sbsgroup widths="45% 10% 45%">
             <sidebyside valign="middle">
 	      <image>
@@ -952,13 +959,6 @@
               </image>
 	    </sidebyside>
           </sbsgroup>
-	  <caption>
-	    The transformation defined by <m>A=QDQ^T</m> can be
-	    interpreted as a sequence of geometric transformations:
-	    <m>Q^T</m> rotates by <m>-45^\circ</m>, <m>D</m>
-	    stretches and reflects, and <m>Q</m> rotates by
-	    <m>45^\circ</m>. 
-	  </caption>
 	</figure>
 
 	<p>
@@ -1352,6 +1352,9 @@
 	      </p>
 
 	      <figure xml:id="fig-variance-data">
+		<caption>
+		  Plot the data points and their centroid here.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A standard coordinate grid and set of axes.
@@ -1366,9 +1369,6 @@
                     <xi:include href="prefigure/section1-1/empty-4.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  Plot the data points and their centroid here.
-		</caption>
 	      </figure>
 
 	    </li>
@@ -1386,6 +1386,9 @@
 		and plot them in <xref ref="fig-variance-demeaned" />.
 	      </p>
 	      <figure xml:id="fig-variance-demeaned">
+		<caption>
+		  Plot the demeaned data points <m>\dtil_j</m> here.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A standard coordinate grid and set of axes.
@@ -1400,9 +1403,6 @@
                     <xi:include href="prefigure/section1-1/empty-4.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  Plot the demeaned data points <m>\dtil_j</m> here.
-		</caption>
 	      </figure>
 	    </li>
 
@@ -1430,6 +1430,10 @@
 	      </p>
 
 	      <figure xml:id="fig-variance-projection">
+		<caption>
+		  Plot the projections of the demeaned data onto the
+		  <m>x</m> and <m>y</m> axes.
+		</caption>
 		<sidebyside widths="45% 45%">
 		  <image>
                     <shortdescription>
@@ -1460,10 +1464,6 @@
                     </prefigure>
 		  </image>
                 </sidebyside>
-		<caption>
-		  Plot the projections of the demeaned data onto the
-		  <m>x</m> and <m>y</m> axes.
-		</caption>
 	      </figure>
 	    </li>
 
@@ -1496,6 +1496,10 @@
 	      </p>
 	      
 	      <figure xml:id="fig-variance-projection-2">
+		<caption>
+		    Plot the projections of the deameaned data onto the
+		    lines defined by <m>\vvec_1</m> and <m>\vvec_2</m>.
+		</caption>
 		<image width="50%">
                   <shortdescription>
                     A coordinate grid and set of axes along with two
@@ -1512,10 +1516,6 @@
                     <xi:include href="prefigure/section7-1/empty-4-diag.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		    Plot the projections of the deameaned data onto the
-		    lines defined by <m>\vvec_1</m> and <m>\vvec_2</m>.
-		</caption>
 	      </figure>
 	    </li>
 

--- a/src/section7-2.xml
+++ b/src/section7-2.xml
@@ -41,6 +41,10 @@
 	  </p>
           <p component="rs-preview">You can scan and upload your sketch below.</p>
 	  <figure xml:id="fig-quad-preview">
+	    <caption>
+	      Use this coordinate grid to plot the demeaned data
+	      points.
+	    </caption>
 	    <image width="50%">
               <shortdescription>
                 A standard coordinate grid and set of axes.
@@ -55,10 +59,6 @@
                 <xi:include href="prefigure/section1-1/empty-4.xml"/>
               </prefigure>
             </image>
-	    <caption>
-	      Use this coordinate grid to plot the demeaned data
-	      points.
-	    </caption>
 	  </figure>
         </statement>
         <response component="rs-preview"/>
@@ -896,6 +896,10 @@ quad_plot(A)
 	</p>
 
 	<figure xml:id="fig-covariance-quad">
+	  <caption>
+	      The set of demeaned data points from <xref
+	      ref="preview-quadforms" />.
+	  </caption>
 	  <image width="50%">
             <shortdescription>
               A coordinate grid and axes with three data points.
@@ -910,10 +914,6 @@ quad_plot(A)
               <xi:include href="prefigure/section7-2/quad-variance-data.xml"/>
             </prefigure>
           </image>
-	  <caption>
-	      The set of demeaned data points from <xref
-	      ref="preview-quadforms" />.
-	  </caption>
 	</figure>
 
 	<p>
@@ -941,6 +941,11 @@ quad_plot(A)
 	</p>
 
 	<figure xml:id="fig-quad-project">
+	  <caption>
+	    The demeaned data from <xref ref="preview-quadforms" />
+	    is shown projected onto the lines of maximal and minimal
+	    variance.
+	  </caption>
 	  <sidebyside widths="45% 45%">
 	    <image>
               <shortdescription>
@@ -984,11 +989,6 @@ quad_plot(A)
               </prefigure>
             </image>
 	  </sidebyside>
-	  <caption>
-	    The demeaned data from <xref ref="preview-quadforms" />
-	    is shown projected onto the lines of maximal and minimal
-	    variance.
-	  </caption>
 	</figure>
 
 	<p>

--- a/src/section7-3.xml
+++ b/src/section7-3.xml
@@ -704,6 +704,12 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
     </p>
 
     <figure xml:id="fig-pca-coords">
+      <caption>
+	The projection <m>\xhat</m> of a data point <m>\xvec</m> onto
+	<m>W_2</m> is a three-dimensional vector, which may be
+	represented by the two coordinates describing this vector as a
+	linear combination of <m>\uvec_1</m> and <m>\uvec_2</m>.
+      </caption>
       <sidebyside widths="50% 40%">
 	<image>
           <shortdescription>
@@ -746,12 +752,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
           </prefigure>
         </image>
       </sidebyside>
-      <caption>
-	The projection <m>\xhat</m> of a data point <m>\xvec</m> onto
-	<m>W_2</m> is a three-dimensional vector, which may be
-	represented by the two coordinates describing this vector as a
-	linear combination of <m>\uvec_1</m> and <m>\uvec_2</m>.
-      </caption>
     </figure>
 
     <p>
@@ -854,6 +854,10 @@ df
 	      </p>
 
 	      <figure xml:id="fig-pca-1d">
+		<caption>
+		  A plot of the demeaned data projected onto the
+		  first principal component.
+		</caption>
 		<image width="90%">
                   <shortdescription>
                     A number line suitable for
@@ -869,10 +873,6 @@ df
                     <xi:include href="prefigure/section7-3/pca-plot-1.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  A plot of the demeaned data projected onto the
-		  first principal component.
-		</caption>
 	      </figure>
 	    </li>
 
@@ -900,6 +900,10 @@ df
 	      </p>
 
 	      <figure xml:id="fig-pca-2d">
+		<caption>
+		  The coordinates of the demeaned data points
+		  projected onto the first two principal components.
+		</caption>
 		<image width="90%">
                   <shortdescription>
                     A coordinate grid and set of axes suitable for
@@ -917,10 +921,6 @@ df
                     <xi:include href="prefigure/section7-3/pca-plot-2.xml"/>
                   </prefigure>
                 </image>
-		<caption>
-		  The coordinates of the demeaned data points
-		  projected onto the first two principal components.
-		</caption>
 	      </figure>
 	    </li>
 
@@ -1214,17 +1214,6 @@ df
 	</p>
 
 	<figure xml:id="fig-iris">
-	  <sidebyside width="70%">
-	    <image source="images/Iris_versicolor.jpg">
-              <shortdescription>
-                A photograph of an iris versicolor.
-              </shortdescription>
-              <description>
-                <p>A photograph of an iris versicolor showing three
-                shorter petals and three longer sepals.</p>
-              </description>
-            </image>
-	  </sidebyside>
 	  <caption>
 	    One of the three species, iris versicolor, represented
 	    in the dataset showing three shorter petals and three
@@ -1241,6 +1230,17 @@ df
 		  visual="gvsu.edu/s/21E">
 		GNU Free Documetation License</url>)	      
 	  </caption>
+	  <sidebyside width="70%">
+	    <image source="images/Iris_versicolor.jpg">
+              <shortdescription>
+                A photograph of an iris versicolor.
+              </shortdescription>
+              <description>
+                <p>A photograph of an iris versicolor showing three
+                shorter petals and three longer sepals.</p>
+              </description>
+            </image>
+	  </sidebyside>
 	</figure>
 
 	<p>

--- a/src/section7-4.xml
+++ b/src/section7-4.xml
@@ -250,7 +250,7 @@
 	  <caption>
 	    Singular values, right singular vectors and left singular
 	    vectors 
-	  </caption>  
+	  </caption>
 	  
 	  <interactive xml:id="interactive-svd"
 		       platform="javascript" width="100%"


### PR DESCRIPTION
As part of the schema cleanup, this PR reorganizes `figure` elements so that a `caption` element appears before content, such as `image` or `sidebyside`.