### PR TITLE
<answer>s moved before <solution>s

### DIFF
--- a/src/exercises/exercises1-2.xml
+++ b/src/exercises/exercises1-2.xml
@@ -69,6 +69,56 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> The reduced row echelon form is
+	<md>
+	  \left[\begin{array}{rr|r}
+	  1 \amp 0 \amp -1 \\
+	  0 \amp 1 \amp 2 \\
+	  0 \amp 0 \amp 0 \\
+	  \end{array}\right]\text{,}
+	</md>
+	and there is a single solution.  Every variable is basic.
+	</p></li>
+
+	<li><p>
+	  The reduced row echelon form is
+	  <md>
+	    \left[\begin{array}{rrr|r}
+	    1 \amp 0 \amp 0 \amp -1 \\
+	    0 \amp 1 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 1 \amp 1 \\
+	    \end{array}\right]\text{.}
+	  </md>
+	  All the variables are basic so there is a unique solution:
+	  <m>x_1 = -1</m>, <m>x_2=0</m>, and <m>x_3=1</m>.
+	</p></li>
+
+	<li><p>
+	  The reduced row echelon form is
+	  <md>
+	    \left[\begin{array}{rrrr|r}
+	    1 \amp 0 \amp -1 \amp 0 \amp 2 \\
+	    0 \amp 1 \amp -2 \amp 0 \amp -3 \\
+	    0 \amp 0 \amp 0 \amp 1 \amp -1 \\
+	    0 \amp 0 \amp 0 \amp 0 \amp 0
+	    \end{array}\right]\text{,}
+	  </md>
+	  which gives the equations
+	  <md>
+	    \begin{aligned}
+	    x_1 \amp = 2 + x_3 \\
+	    x_2 \amp = -3 + 2x_3 \\
+	    x_4 \amp = -1 - x_3. \\
+	    \end{aligned}
+	  </md>
+	  This shows that <m>x_3</m> is a free variable and <m>x_1</m>,
+	  <m>x_2</m>, and <m>x_4</m> are basic variables.  There are
+	  therefore infinitely many solutions.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The augmented matrix and its reduced row echelon form
@@ -152,57 +202,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> The reduced row echelon form is
-	<md>
-	  \left[\begin{array}{rr|r}
-	  1 \amp 0 \amp -1 \\
-	  0 \amp 1 \amp 2 \\
-	  0 \amp 0 \amp 0 \\
-	  \end{array}\right]\text{,}
-	</md>
-	and there is a single solution.  Every variable is basic.
-	</p></li>
 
-	<li><p>
-	  The reduced row echelon form is
-	  <md>
-	    \left[\begin{array}{rrr|r}
-	    1 \amp 0 \amp 0 \amp -1 \\
-	    0 \amp 1 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 1 \amp 1 \\
-	    \end{array}\right]\text{.}
-	  </md>
-	  All the variables are basic so there is a unique solution: 
-	  <m>x_1 = -1</m>, <m>x_2=0</m>, and <m>x_3=1</m>.
-	</p></li>
-
-	<li><p>
-	  The reduced row echelon form is
-	  <md>
-	    \left[\begin{array}{rrrr|r}
-	    1 \amp 0 \amp -1 \amp 0 \amp 2 \\
-	    0 \amp 1 \amp -2 \amp 0 \amp -3 \\
-	    0 \amp 0 \amp 0 \amp 1 \amp -1 \\
-	    0 \amp 0 \amp 0 \amp 0 \amp 0
-	    \end{array}\right]\text{,}
-	  </md>
-	  which gives the equations
-	  <md>
-	    \begin{aligned}
-	    x_1 \amp = 2 + x_3 \\
-	    x_2 \amp = -3 + 2x_3 \\
-	    x_4 \amp = -1 - x_3. \\
-	    \end{aligned}
-	  </md>
-	  This shows that <m>x_3</m> is a free variable and <m>x_1</m>,
-	  <m>x_2</m>, and <m>x_4</m> are basic variables.  There are
-	  therefore infinitely many solutions.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -269,6 +269,65 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li> <p> The reduced row echelon form is
+	  <md>
+	    \left[
+	    \begin{array}{rrrr|r}
+	    1 \amp 0 \amp 0 \amp 5 \amp 2 \\
+	    0 \amp 1 \amp 0 \amp -2 \amp 1 \\
+	    0 \amp 0 \amp 1 \amp 3 \amp 4 \\
+	    \end{array}
+	    \right]\text{,}
+	  </md>
+	  and there are infinitely many solutions.
+	</p> </li>
+
+	<li> <p> The reduced row echelon form is
+	  <md>
+	    \left[
+	    \begin{array}{rrrr|r}
+	    1 \amp 0 \amp 0 \amp 0 \amp 0 \\
+	    0 \amp 1 \amp 0 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 1 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 0 \amp 1 \amp 0 \\
+	    0 \amp 0 \amp 0 \amp 0 \amp 1 \\
+	    \end{array}
+	    \right]\text{,}
+	  </md>
+	  and there are no solutions.
+	</p> </li>
+
+	<li> <p> The reduced row echelon form is
+	  <md>
+	    \left[
+	    \begin{array}{rrrr|r}
+	    1 \amp 0 \amp 0 \amp 0 \amp 0 \\
+	    0 \amp 1 \amp 0 \amp 0 \amp 3 \\
+	    0 \amp 0 \amp 1 \amp 0 \amp 1 \\
+	    0 \amp 0 \amp 0 \amp 1 \amp 1 \\
+	    \end{array}
+	    \right]\text{,}
+	  </md>
+	  and this linear system has a single solution.
+	</p> </li>
+
+	<li> <p> The reduced row echelon form is
+	  <md>
+	    \left[
+	    \begin{array}{rrrr|r}
+	    1 \amp 0 \amp 0 \amp 1 \amp 0 \\
+	    0 \amp 1 \amp 0 \amp 0 \amp 3 \\
+	    0 \amp 0 \amp 1 \amp 0 \amp -1 \\
+	    \end{array}
+	    \right]\text{,}
+	  </md>
+	  and there are infinitely many solutions.
+	</p> </li>
+      </ol>
+      </p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li> <p> This is not in reduced row echelon form since the
@@ -374,66 +433,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li> <p> The reduced row echelon form is
-	  <md>
-	    \left[
-	    \begin{array}{rrrr|r}
-	    1 \amp 0 \amp 0 \amp 5 \amp 2 \\
-	    0 \amp 1 \amp 0 \amp -2 \amp 1 \\
-	    0 \amp 0 \amp 1 \amp 3 \amp 4 \\
-	    \end{array}
-	    \right]\text{,}
-	  </md>
-	  and there are infinitely many solutions.
-	</p> </li>
 
-	<li> <p> The reduced row echelon form is
-	  <md>
-	    \left[
-	    \begin{array}{rrrr|r}
-	    1 \amp 0 \amp 0 \amp 0 \amp 0 \\
-	    0 \amp 1 \amp 0 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 1 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 0 \amp 1 \amp 0 \\
-	    0 \amp 0 \amp 0 \amp 0 \amp 1 \\
-	    \end{array}
-	    \right]\text{,}
-	  </md>
-	  and there are no solutions.
-	</p> </li>
-
-	<li> <p> The reduced row echelon form is
-	  <md>
-	    \left[
-	    \begin{array}{rrrr|r}
-	    1 \amp 0 \amp 0 \amp 0 \amp 0 \\
-	    0 \amp 1 \amp 0 \amp 0 \amp 3 \\
-	    0 \amp 0 \amp 1 \amp 0 \amp 1 \\
-	    0 \amp 0 \amp 0 \amp 1 \amp 1 \\
-	    \end{array}
-	    \right]\text{,}
-	  </md>
-	  and this linear system has a single solution.
-	</p> </li>
-
-	<li> <p> The reduced row echelon form is
-	  <md>
-	    \left[
-	    \begin{array}{rrrr|r}
-	    1 \amp 0 \amp 0 \amp 1 \amp 0 \\
-	    0 \amp 1 \amp 0 \amp 0 \amp 3 \\
-	    0 \amp 0 \amp 1 \amp 0 \amp -1 \\
-	    \end{array}
-	    \right]\text{,}
-	  </md>
-	  and there are infinitely many solutions.
-	</p> </li>
-      </ol>
-      </p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -465,6 +465,55 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	<m>
+	  \left[\begin{array}{rrr|r}
+	  1 \amp 0 \amp 0 \amp 3 \\
+	  0 \amp 1 \amp 0 \amp -4 \\
+	  0 \amp 0 \amp 1 \amp 2 \\
+	  0 \amp 0 \amp 0 \amp 0 \\
+	  0 \amp 0 \amp 0 \amp 0 \\
+	  \end{array}\right]\text{.}
+	</m>
+	</p></li>
+
+	<li><p>
+	<m>
+	  \left[\begin{array}{rrr|r}
+	  1 \amp 0 \amp -2 \amp 0 \\
+	  0 \amp 1 \amp 1 \amp 0 \\
+	  0 \amp 0 \amp 0 \amp 1 \\
+	  \end{array}\right]\text{.}
+	</m>
+	</p></li>
+
+	<li><p>
+	<m>
+	  \left[\begin{array}{rrrrr|r}
+	  1 \amp 0 \amp 0 \amp -2 \amp 3 \amp 7 \\
+	  0 \amp 1 \amp 0 \amp 3 \amp 0 \amp 4 \\
+	  0 \amp 0 \amp 1 \amp 1 \amp -1 \amp 2 \\
+	  \end{array}\right]\text{.}
+	</m>
+	</p></li>
+
+	<li><p> This is not possible.
+	</p></li>
+
+	<li><p>
+	<m>
+	  \left[\begin{array}{rrrr|r}
+	  1 \amp 0 \amp 0 \amp 0 \amp 1 \\
+	  0 \amp 1 \amp 0 \amp 0 \amp -2 \\
+	  0 \amp 0 \amp 1 \amp 0 \amp 0 \\
+	  0 \amp 0 \amp 0 \amp 1 \amp 1 \\
+	  \end{array}\right]\text{.}
+	</m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Our matrix should have five rows and four columns.
@@ -524,57 +573,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> 
-	<m>
-	  \left[\begin{array}{rrr|r}
-	  1 \amp 0 \amp 0 \amp 3 \\
-	  0 \amp 1 \amp 0 \amp -4 \\
-	  0 \amp 0 \amp 1 \amp 2 \\
-	  0 \amp 0 \amp 0 \amp 0 \\
-	  0 \amp 0 \amp 0 \amp 0 \\
-	  \end{array}\right]\text{.}
-	</m>
-	</p></li>
 
-	<li><p> 
-	<m>
-	  \left[\begin{array}{rrr|r}
-	  1 \amp 0 \amp -2 \amp 0 \\
-	  0 \amp 1 \amp 1 \amp 0 \\
-	  0 \amp 0 \amp 0 \amp 1 \\
-	  \end{array}\right]\text{.}
-	</m>
-	</p></li>
 
-	<li><p> 
-	<m>
-	  \left[\begin{array}{rrrrr|r}
-	  1 \amp 0 \amp 0 \amp -2 \amp 3 \amp 7 \\
-	  0 \amp 1 \amp 0 \amp 3 \amp 0 \amp 4 \\
-	  0 \amp 0 \amp 1 \amp 1 \amp -1 \amp 2 \\
-	  \end{array}\right]\text{.}
-	</m>
-	</p></li>
-
-	<li><p> This is not possible.  
-	</p></li>
-
-	<li><p> 
-	<m>
-	  \left[\begin{array}{rrrr|r}
-	  1 \amp 0 \amp 0 \amp 0 \amp 1 \\
-	  0 \amp 1 \amp 0 \amp 0 \amp -2 \\
-	  0 \amp 0 \amp 1 \amp 0 \amp 0 \\
-	  0 \amp 0 \amp 0 \amp 1 \amp 1 \\
-	  \end{array}\right]\text{.}
-	</m>
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -639,6 +639,34 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Interchange the second and third rows.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Scale the second row by <m>-1/2</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Perform interchanges among the first three rows.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Perform row replacement operations so that the leading
+	      entry in the third row is the only nonzero entry in its
+	      column.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -726,34 +754,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Interchange the second and third rows.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Scale the second row by <m>-1/2</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Perform interchanges among the first three rows.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Perform row replacement operations so that the leading
-	      entry in the third row is the only nonzero entry in its
-	      column. 
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -780,6 +780,22 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Nothing. </p></li>
+
+	<li><p> The leading entry of some row appears in the rightmost
+	column of the augmented matrix.
+	</p></li>
+
+	<li><p> There is a column that is not the rightmost and that
+	does not contain the leading entry of a row.  Also, the
+	rightmost column does not contain a leading entry.
+	</p></li>
+
+	<li><p> There are infinitely many solutions. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> It doesn't tell us anything.  The equation is true for
@@ -806,23 +822,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Nothing. </p></li>
 
-	<li><p> The leading entry of some row appears in the rightmost
-	column of the augmented matrix.
-	</p></li>
-
-	<li><p> There is a column that is not the rightmost and that
-	does not contain the leading entry of a row.  Also, the
-	rightmost column does not contain a leading entry.
-	</p></li>
-
-	<li><p> There are infinitely many solutions. </p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -850,6 +850,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> True. </p></li>
+	<li><p> True. </p></li>
+	<li><p> False. </p></li>
+	<li><p> False. </p></li>
+	<li><p> False. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> This is true provided that there is some solution to
@@ -893,16 +902,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> True. </p></li>
-	<li><p> True. </p></li>
-	<li><p> False. </p></li>
-	<li><p> False. </p></li>
-	<li><p> False. </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises1-3.xml
+++ b/src/exercises/exercises1-3.xml
@@ -21,6 +21,11 @@
     </sage>
   </statement>
 
+  <answer>
+    <p>
+      There is exactly one solution <m>(3,-1,0)</m>.
+    </p>
+  </answer>
   <solution>
     <p> We can use Sage to find the reduced row echelon form of the
     corresponding augmented matrix:
@@ -41,12 +46,7 @@
     </p>
   </solution>
 
-  <answer>
-    <p>
-      There is exactly one solution <m>(3,-1,0)</m>.
-    </p>
-  </answer>
-      
+
 </exercise>
 
 <exercise>
@@ -192,6 +192,32 @@
     </ol> </p>
   </statement>
 
+  <answer>
+    <p>
+      <ol marker="a.">
+	<li>
+	  <p>
+	    There is one solution: <m>x=400</m>, <m>y=300</m>,
+	    <m>z=550</m>, and <m>w=160</m>.
+	  </p>
+	</li>
+
+	<li>
+	  <p>
+	    There are infinitely many solutions described by
+	    <md>
+	      \begin{alignedat}{3}
+	      x \amp {}={} \amp 70 + w \\
+	      y \amp {}={} \amp 580 - w \\
+	      z \amp {}={} \amp 220 + w\text{.} \\
+	      \end{alignedat}
+	    </md>
+	  </p>
+	</li>
+
+      </ol>
+    </p>
+  </answer>
   <solution>
     <p><ol marker="a.">
       <li>
@@ -330,33 +356,7 @@
     </p>
   </solution>
 
-  <answer>
-    <p>
-      <ol marker="a.">
-	<li>
-	  <p>
-	    There is one solution: <m>x=400</m>, <m>y=300</m>,
-	    <m>z=550</m>, and <m>w=160</m>.
-	  </p>
-	</li>
 
-	<li>
-	  <p>
-	    There are infinitely many solutions described by 
-	    <md>
-	      \begin{alignedat}{3}
-	      x \amp {}={} \amp 70 + w \\
-	      y \amp {}={} \amp 580 - w \\
-	      z \amp {}={} \amp 220 + w\text{.} \\
-	      \end{alignedat}
-	    </md>
-	  </p>
-	</li>
-
-      </ol>
-    </p>
-  </answer>
-  
 </exercise>
 
 <exercise>
@@ -438,6 +438,16 @@ A.rref().numerical_approx(digits=4)
 
   </statement>
 
+  <answer>
+    <p>
+      <md>
+	\begin{array}{rrr}
+	T_1 = 14.86, \amp T_2 = 20.50, \amp T_3 = 26.19 \\
+	T_4 = 13.95, \amp T_5 = 20.93, \amp T_6 = 29.28\text{.} \\
+	\end{array}
+      </md>
+    </p>
+  </answer>
   <solution>
     <p>
       We set up the equations
@@ -469,17 +479,7 @@ A.rref().numerical_approx(digits=4)
     </p>
   </solution>
 
-  <answer>
-    <p>
-      <md>
-	\begin{array}{rrr}
-	T_1 = 14.86, \amp T_2 = 20.50, \amp T_3 = 26.19 \\
-	T_4 = 13.95, \amp T_5 = 20.93, \amp T_6 = 29.28\text{.} \\
-	\end{array}
-      </md>
-    </p>
-  </answer>
-	
+
 </exercise>
 
 <exercise>
@@ -517,6 +517,12 @@ A.rref().numerical_approx(digits=4)
     </p>
   </statement>
 
+  <answer>
+    <p> The first shift produces <m>x=113</m> pounds while the second
+    shift produces <m>y=65</m> pounds.  There are <m>30.8</m>
+    pounds of sulfur.
+    </p>
+  </answer>
   <solution>
     <p>
       <ol marker="a.">
@@ -545,12 +551,6 @@ A.rref().numerical_approx(digits=4)
     </p>
   </solution>
 
-  <answer>
-    <p> The first shift produces <m>x=113</m> pounds while the second
-    shift produces <m>y=65</m> pounds.  There are <m>30.8</m>
-    pounds of sulfur.
-    </p>
-  </answer>
 </exercise>
 
 <exercise>
@@ -632,6 +632,33 @@ A.rref().numerical_approx(digits=4)
     </p>
   </statement>
 
+  <answer>
+    <p>
+      <ol marker="a.">
+	<li>
+	  <p> We have the reaction
+	  <md>
+	    2\thinspace \text{H}_2 + \thinspace\text{O}_2 \to
+	    2\thinspace \text{H}_2\text{O}\text{.}
+	  </md>
+	  </p>
+	</li>
+
+	<li>
+	  <p> We have the reaction
+	  <md>
+	    2\thinspace \text{K}\text{Mn}\text{O}_4 +
+	    3\thinspace \text{Mn}\text{S}\text{O}_4 +
+	    2\thinspace \text{H}_2\text{O} \to
+	    5\thinspace \text{Mn}\text{O}_2 +
+	    \thinspace \text{K}_2\text{S}\text{O}_4 +
+	    2\thinspace \text{H}_2\text{S}\text{O}_4.
+	  </md>
+	  </p>
+	</li>
+      </ol>
+    </p>
+  </answer>
   <solution>
     <p>
       <ol marker="a.">
@@ -753,34 +780,7 @@ A.rref().numerical_approx(digits=4)
     </p>
   </solution>
 
-  <answer>
-    <p>
-      <ol marker="a.">
-	<li>
-	  <p> We have the reaction
-	  <md>
-	    2\thinspace \text{H}_2 + \thinspace\text{O}_2 \to
-	    2\thinspace \text{H}_2\text{O}\text{.}
-	  </md>
-	  </p>
-	</li>
 
-	<li>
-	  <p> We have the reaction
-	  <md>
-	    2\thinspace \text{K}\text{Mn}\text{O}_4 + 
-	    3\thinspace \text{Mn}\text{S}\text{O}_4 + 
-	    2\thinspace \text{H}_2\text{O} \to
-	    5\thinspace \text{Mn}\text{O}_2 + 
-	    \thinspace \text{K}_2\text{S}\text{O}_4 + 
-	    2\thinspace \text{H}_2\text{S}\text{O}_4.
-	  </md>
-	  </p>
-	</li>
-      </ol>
-    </p>
-  </answer>
-		  
 </exercise>
 
 <exercise>
@@ -915,6 +915,32 @@ A.rref().numerical_approx(digits=4)
     </p>
   </statement>
 
+  <answer>
+    <p>
+      <ol marker="a.">
+	<li>
+	  <p>
+	    The exact solution is
+	    <md>
+	      x=9, y=-36, z=30
+	    </md>
+	    while the approximate solution is
+	    <md>
+	      x=8.9, y=-35, z=29\text{.}
+	    </md>
+	  </p>
+	</li>
+
+	<li>
+	  <p>
+	    This solution to the first system is <m>x=2</m> and
+	    <m>y=0</m>.  However, with just a small change in the
+	    system, we find the solution <m>x=1</m> and <m>y=1</m>.
+	  </p>
+	</li>
+      </ol>
+    </p>
+  </answer>
   <solution>
     <p>
       <ol marker="a.">
@@ -943,32 +969,6 @@ A.rref().numerical_approx(digits=4)
     </p>
   </solution>
 
-  <answer>
-    <p>
-      <ol marker="a.">
-	<li>
-	  <p>
-	    The exact solution is
-	    <md>
-	      x=9, y=-36, z=30
-	    </md>
-	    while the approximate solution is
-	    <md>
-	      x=8.9, y=-35, z=29\text{.}
-	    </md>
-	  </p>
-	</li>
-
-	<li>
-	  <p>
-	    This solution to the first system is <m>x=2</m> and
-	    <m>y=0</m>.  However, with just a small change in the
-	    system, we find the solution <m>x=1</m> and <m>y=1</m>.
-	  </p>
-	</li>
-      </ol>
-    </p>
-  </answer>
 </exercise>
 
 </exercises>

--- a/src/exercises/exercises1-4.xml
+++ b/src/exercises/exercises1-4.xml
@@ -64,6 +64,35 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p>
+	    The linear system is consistent because there is not
+	    a pivot position in the rightmost column, and
+	    there are infinitely many
+	    solutions.
+	  </p></li>
+
+	  <li><p>
+	    The linear system is consistent because there is not
+	    a pivot position in the rightmost column, and
+	    there are infinitely many
+	    solutions.
+	  </p></li>
+
+	  <li><p>
+	    The linear system is inconsistent because there is a pivot
+	    position in the rightmost column.
+	  </p></li>
+
+	  <li><p>
+	    The linear system is consistent, and there is a unique
+	    solution.
+	  </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -97,36 +126,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p>
-	    The linear system is consistent because there is not
-	    a pivot position in the rightmost column, and
-	    there are infinitely many
-	    solutions. 
-	  </p></li>
 
-	  <li><p>
-	    The linear system is consistent because there is not
-	    a pivot position in the rightmost column, and 
-	    there are infinitely many
-	    solutions. 
-	  </p></li>
-
-	  <li><p>
-	    The linear system is inconsistent because there is a pivot
-	    position in the rightmost column.
-	  </p></li>
-
-	  <li><p>
-	    The linear system is consistent, and there is a unique
-	    solution. 
-	  </p></li>
-	</ol>
-      </p>
-    </answer>
-	    
   </exercise>
 
   <exercise>
@@ -193,6 +193,28 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The linear system is consistent with a unique solution.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The linear system is consistent with infinitely many
+	      solutions.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The linear system is inconsistent.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -275,28 +297,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The linear system is consistent with a unique solution.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The linear system is consistent with infinitely many
-	      solutions. 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The linear system is inconsistent.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
 
@@ -321,6 +321,24 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p>
+	    We cannot guarantee either possibility.
+	  </p></li>
+
+	  <li><p>
+	    We can guarantee there are infinitely many solutions.
+	  </p></li>
+
+	  <li><p>
+	    There is a pivot position in each column of the
+	    coefficient matrix.
+	  </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -391,25 +409,7 @@
 	</ol>
       </p>
     </solution>
-	      
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p>
-	    We cannot guarantee either possibility.
-	  </p></li>
 
-	  <li><p>
-	    We can guarantee there are infinitely many solutions.
-	  </p></li>
-
-	  <li><p>
-	    There is a pivot position in each column of the
-	    coefficient matrix.
-	  </p></li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -451,6 +451,17 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p> False. </p></li>
+	  <li><p> False. </p></li>
+	  <li><p> False. </p></li>
+	  <li><p> True. </p></li>
+	  <li><p> False. </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -510,18 +521,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p> False. </p></li>
-	  <li><p> False. </p></li>
-	  <li><p> False. </p></li>
-	  <li><p> True. </p></li>
-	  <li><p> False. </p></li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -562,6 +562,29 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The planes will most likely intersect either in a line
+	      or not at all.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      There must be infinitely many solutions.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      There will most likely be a pivot position in the
+	      rightmost column of the augmented matrix.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -635,29 +658,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The planes will most likely intersect either in a line
-	      or not at all.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      There must be infinitely many solutions.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      There will most likely be a pivot position in the
-	      rightmost column of the augmented matrix.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 	      
 
@@ -691,6 +691,24 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p>
+	    The system is consistent when <m>k=
+	    -6</m>, and the solution can never be unique.  If <m>k\neq
+	    -6</m>, the system is inconsistent.
+	  </p></li>
+
+	  <li><p>
+	    The system is inconsistent if <m>k=-2</m> and <m>l\neq
+	    -\frac32</m>.  There are infinitely many solutions if
+	    <m>k=-2</m> and <m>l=-\frac32</m>.  There is a unique
+	    solution if <m>k\neq -2</m>.
+	  </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -734,25 +752,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p> 
-	    The system is consistent when <m>k=
-	    -6</m>, and the solution can never be unique.  If <m>k\neq
-	    -6</m>, the system is inconsistent.
-	  </p></li>
 
-	  <li><p>
-	    The system is inconsistent if <m>k=-2</m> and <m>l\neq
-	    -\frac32</m>.  There are infinitely many solutions if
-	    <m>k=-2</m> and <m>l=-\frac32</m>.  There is a unique
-	    solution if <m>k\neq -2</m>.
-	  </p></li>
-	</ol>
-      </p>
-    </answer>
-	    
   </exercise>
 
   <exercise>
@@ -787,6 +787,23 @@
       </p>
     </statement>
 
+    <answer>
+      <p> Some example choices are given here, but there are many more.
+	<ol marker="a.">
+	  <li><p>
+	    <m>a=b=c=0</m>.
+	  </p></li>
+
+	  <li><p>
+	    <m>a=1</m> and <m>b=c=0</m>.
+	  </p></li>
+
+	  <li><p>
+	    <m>a=9</m>, <m>b=0</m>, and <m>c=-9</m>.
+	  </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	We have
@@ -827,23 +844,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p> Some example choices are given here, but there are many more.
-	<ol marker="a.">
-	  <li><p>
-	    <m>a=b=c=0</m>.
-	  </p></li>
-
-	  <li><p>
-	    <m>a=1</m> and <m>b=c=0</m>.
-	  </p></li>
-
-	  <li><p>
-	    <m>a=9</m>, <m>b=0</m>, and <m>c=-9</m>.
-	  </p></li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -895,6 +895,21 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p> There cannot be a pivot in the rightmost
+	  column.</p></li>
+
+	  <li><p> There is a solution when all the variables are set
+	  to zero.
+	  </p></li>
+
+	  <li><p> There are at least as many equations as variables.
+	  </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -928,21 +943,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p> There cannot be a pivot in the rightmost
-	  column.</p></li>
-
-	  <li><p> There is a solution when all the variables are set
-	  to zero.
-	  </p></li>
-
-	  <li><p> There are at least as many equations as variables.
-	  </p></li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise xml:id="exercise-poly-fit">
@@ -1071,6 +1071,52 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p>
+	    The four equations we find are
+	    <md>
+	      \begin{alignedat}{5}
+	      a \amp \amp \amp \amp \amp \amp
+	      \amp {}={} \amp 2 \\
+	      a \amp {}+{} \amp b \amp {}+{} \amp c \amp {}+{} \amp d
+	      \amp {}={} \amp 3 \\
+	      a \amp {}+{} \amp 2b \amp {}+{} \amp 4c \amp {}+{} \amp 8d
+	      \amp {}={} \amp 0 \\
+	      a \amp {}+{} \amp 3b \amp {}+{} \amp 9c \amp {}+{} \amp 27d
+	      \amp {}={} \amp 1\text{.} \\
+	      \end{alignedat}
+	    </md>
+	  </p></li>
+
+	  <li><p>
+	    The coefficients are <m>a=2</m>,
+	    <m>b=\frac{17}{3}</m>, <m>c=-6</m>, and <m>d=\frac43</m>.
+	  </p></li>
+
+	  <li><p>
+	    The polynomial is
+	    <md>
+	      p(x) = 2 + \frac{17}{3}x -6x^2 + \frac43 x^3\text{.}
+	    </md>
+	  </p></li>
+
+	  <li><p>
+	    The linear system is inconsistent.
+	  </p></li>
+
+	  <li><p>
+	    The linear system is consistent with infinitely many
+	    solutions.
+	  </p></li>
+
+	  <li><p>
+	    Nine.
+	  </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1170,53 +1216,7 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p>
-	    The four equations we find are
-	    <md>
-	      \begin{alignedat}{5}
-	      a \amp \amp \amp \amp \amp \amp 
-	      \amp {}={} \amp 2 \\
-	      a \amp {}+{} \amp b \amp {}+{} \amp c \amp {}+{} \amp d
-	      \amp {}={} \amp 3 \\
-	      a \amp {}+{} \amp 2b \amp {}+{} \amp 4c \amp {}+{} \amp 8d
-	      \amp {}={} \amp 0 \\
-	      a \amp {}+{} \amp 3b \amp {}+{} \amp 9c \amp {}+{} \amp 27d
-	      \amp {}={} \amp 1\text{.} \\
-	      \end{alignedat}
-	    </md>
-	  </p></li>
 
-	  <li><p>
-	    The coefficients are <m>a=2</m>,
-	    <m>b=\frac{17}{3}</m>, <m>c=-6</m>, and <m>d=\frac43</m>.
-	  </p></li>
-
-	  <li><p>
-	    The polynomial is
-	    <md>
-	      p(x) = 2 + \frac{17}{3}x -6x^2 + \frac43 x^3\text{.}
-	    </md>
-	  </p></li>
-
-	  <li><p>
-	    The linear system is inconsistent.
-	  </p></li>
-
-	  <li><p>
-	    The linear system is consistent with infinitely many
-	    solutions.
-	  </p></li>
-
-	  <li><p>
-	    Nine.
-	  </p></li>
-	</ol>
-      </p>
-    </answer>
 
   </exercise>
   

--- a/src/exercises/exercises2-1.xml
+++ b/src/exercises/exercises2-1.xml
@@ -104,6 +104,37 @@
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li>
+	  <image width="50%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex2-1-1-a-ans">
+              <xi:include href="prefigure/ex2-1-1-a.xml"/>
+            </prefigure>
+          </image>
+	</li>
+
+	<li>
+	  <image width="50%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex2-1-1-b-ans">
+              <xi:include href="prefigure/ex2-1-1-b.xml"/>
+            </prefigure>
+          </image>
+	</li>
+
+	<li><p>
+	  This forms the line passing through <m>2\vvec</m> parallel
+	  to <m>\wvec</m>.
+	</p></li>
+
+	<li><p>
+	  There are many possibilities.  One is
+	  <m>\vvec=\twovec{0}{-2}</m> and <m>\wvec=\twovec{1}{3}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li>
@@ -135,39 +166,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li>
-	  <image width="50%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex2-1-1-a-ans">
-              <xi:include href="prefigure/ex2-1-1-a.xml"/>
-            </prefigure>
-          </image>
-	</li>
-	
-	<li>
-	  <image width="50%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex2-1-1-b-ans">
-              <xi:include href="prefigure/ex2-1-1-b.xml"/>
-            </prefigure>
-          </image>
-	</li>
 
-	<li><p>
-	  This forms the line passing through <m>2\vvec</m> parallel
-	  to <m>\wvec</m>.
-	</p></li>
 
-	<li><p>
-	  There are many possibilities.  One is
-	  <m>\vvec=\twovec{0}{-2}</m> and <m>\wvec=\twovec{1}{3}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -212,6 +212,25 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  We have
+	  <md>
+	    \begin{array}{lll}
+	    p = -\vvec, \amp q = 3\wvec, \amp r=2\vvec+3\wvec, \\
+	    s = 2\vvec-3\wvec, \amp t=-3\vvec-2\wvec, \amp
+	    u=-2\vvec+0.5\wvec, \\
+	    v = 3.5\vvec+1.5\wvec\text{.}
+	    \end{array}
+	  </md>
+	</p></li>
+
+	<li><p> This is the line passing through <m>-2\vvec</m>
+	parallel to <m>\wvec</m>.
+	</p></li>
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -232,26 +251,7 @@
 	</ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  We have
-	  <md>
-	    \begin{array}{lll}
-	    p = -\vvec, \amp q = 3\wvec, \amp r=2\vvec+3\wvec, \\
-	    s = 2\vvec-3\wvec, \amp t=-3\vvec-2\wvec, \amp
-	    u=-2\vvec+0.5\wvec, \\
-	    v = 3.5\vvec+1.5\wvec\text{.}
-	    \end{array}
-	  </md>
-	</p></li>
 
-	<li><p> This is the line passing through <m>-2\vvec</m>
-	parallel to <m>\wvec</m>.
-	</p></li>
-	</ol></p>
-    </answer>
-    
   </exercise>
   
   <exercise>
@@ -299,6 +299,28 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> The linear combination
+	<md>
+	  2\vvec_1-3\vvec_2+\vvec_3 = \twovec{5}{-1}\text{.}
+	</md>
+	</p></li>
+
+	<li><p>
+	  <m>c_1 = \frac23 c_3</m> and
+	  <m>c_2 = -\frac23 c_3</m>.
+	</p></li>
+
+	<li><p>
+	  <m>c_1=c_2=0</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\vvec_3=-\frac23\vvec_1 + \frac23\vvec_2</m>.
+	</p></li>
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The linear combination
@@ -340,30 +362,8 @@
 	</p></li>
 	</ol></p>
     </solution>
-    
-    <answer>
-      <p><ol marker="a.">
-	<li><p> The linear combination
-	<md>
-	  2\vvec_1-3\vvec_2+\vvec_3 = \twovec{5}{-1}\text{.}
-	</md>
-	</p></li>
 
-	<li><p>
-	  <m>c_1 = \frac23 c_3</m> and 
-	  <m>c_2 = -\frac23 c_3</m>.
-	</p></li>
 
-	<li><p>
-	  <m>c_1=c_2=0</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\vvec_3=-\frac23\vvec_1 + \frac23\vvec_2</m>.
-	</p></li>
-	</ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -402,6 +402,30 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>\threevec{120}{105}{1.0}</m>.
+	</p></li>
+
+	<li><p>
+	  The totals consumed are expressed by the vector
+	  <md>
+	    c\threevec{111}{140}{1.2} +
+	    d\threevec{120}{105}{1.0}\text{.}
+	  </md>
+	</p></li>
+
+	<li><p>
+	  You had two servings of Frosted Flakes and
+	  one serving of Cocoa Puffs.
+	</p></li>
+
+	<li><p>
+	  Your sister must have eaten something else.
+	</p></li>
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -458,30 +482,6 @@
 	</ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>\threevec{120}{105}{1.0}</m>.
-	</p></li>
-
-	<li><p>
-	  The totals consumed are expressed by the vector
-	  <md>
-	    c\threevec{111}{140}{1.2} +
-	    d\threevec{120}{105}{1.0}\text{.}
-	  </md>
-	</p></li>
-
-	<li><p>
-	  You had two servings of Frosted Flakes and
-	  one serving of Cocoa Puffs.
-	</p></li>
-
-	<li><p>
-	  Your sister must have eaten something else.
-	</p></li>
-	</ol></p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -528,6 +528,32 @@
 	
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  The vector <m>\bvec</m> may be expressed as
+	  a linear combination of <m>\vvec_1</m>, <m>\vvec_2</m>, and
+	  <m>\vvec_3</m> provided that the weights are related by
+	  <m>c_1=5-2c_3</m> and <m>c_2=2-2c_3</m>.
+	</p></li>
+
+	<li><p>
+	  The vector
+	  <m>\bvec</m> cannot be written as a linear combination of
+	  <m>\vvec_1</m>, <m>\vvec_2</m>, and
+	  <m>\vvec_3</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\vvec_3=2\vvec_1+2\vvec_2</m>.
+	</p></li>
+
+	<li><p>
+	  <m>a\vvec_1+b\vvec_2+c\vvec_3=
+	  (a+2c)\vvec_1+(b+2c)\vvec_2</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -596,34 +622,8 @@
 	</p></li>
       </ol></p>
     </solution>
-    
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  The vector <m>\bvec</m> may be expressed as
-	  a linear combination of <m>\vvec_1</m>, <m>\vvec_2</m>, and
-	  <m>\vvec_3</m> provided that the weights are related by
-	  <m>c_1=5-2c_3</m> and <m>c_2=2-2c_3</m>.
-	</p></li>
 
-	<li><p>
-	  The vector
-	  <m>\bvec</m> cannot be written as a linear combination of 
-	  <m>\vvec_1</m>, <m>\vvec_2</m>, and
-	  <m>\vvec_3</m>.
-	</p></li>
 
-	<li><p>
-	  <m>\vvec_3=2\vvec_1+2\vvec_2</m>.
-	</p></li>
-
-	<li><p>
-	  <m>a\vvec_1+b\vvec_2+c\vvec_3=
-	  (a+2c)\vvec_1+(b+2c)\vvec_2</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -640,6 +640,11 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<m>k=10</m>.
+      </p>
+    </answer>
     <solution>
       <p> We form the augmented matrix and find a triangular matrix
       that is row equivalent:
@@ -660,11 +665,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<m>k=10</m>.
-      </p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -712,6 +712,14 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -750,15 +758,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-      </ol></p>
-    </answer>
-	  
+
 	  
   </exercise>
   
@@ -870,6 +870,36 @@
 	
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>(1,-4) = \{2,-3\}</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\{7/3, -8/3\} = (2,-3)</m>.
+	</p></li>
+
+	<li><p>
+	  <md>
+	    \begin{alignedat}{2}
+	    x \amp {}={} \amp 2c+d \\
+	    y \amp {}={} \amp c+2d\text{.} \\
+	    \end{alignedat}
+	  </md>
+	</p></li>
+
+	<li><p>
+	  Solve the linear system corresponding to the augmented matrix
+	  <md>
+	    \left[\begin{array}{rr|r}
+	    2 \amp 1 \amp x \\
+	    1 \amp 2 \amp y \\
+	    \end{array}\right]\text{.}
+	  </md>
+	</p></li>
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -914,38 +944,8 @@
 	</p></li>
 	</ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>(1,-4) = \{2,-3\}</m>.
-	</p></li>
 
-	<li><p>
-	  <m>\{7/3, -8/3\} = (2,-3)</m>.
-	</p></li>
 
-	<li><p>
-	  <md>
-	    \begin{alignedat}{2}
-	    x \amp {}={} \amp 2c+d \\
-	    y \amp {}={} \amp c+2d\text{.} \\
-	    \end{alignedat}
-	  </md>
-	</p></li>
-
-	<li><p>
-	  Solve the linear system corresponding to the augmented matrix
-	  <md>
-	    \left[\begin{array}{rr|r}
-	    2 \amp 1 \amp x \\
-	    1 \amp 2 \amp y \\
-	    \end{array}\right]\text{.}
-	  </md>
-	</p></li>
-	</ol></p>
-    </answer>
-	
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises2-2.xml
+++ b/src/exercises/exercises2-2.xml
@@ -28,6 +28,23 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m> A = \left[\begin{array}{rrr}
+	  1 \amp 2 \amp -1 \\
+	  3 \amp 2 \amp 2 \\
+	  -1 \amp 0 \amp 4 \\
+	  \end{array}\right]</m>
+	  and <m>\bvec=\threevec{1}{7}{-3}</m>.
+	</p></li>
+
+	<li><p>
+	  There is a unique solution <m>\xvec=\threevec{3}{-1}{0}</m>.
+	</p></li>
+      </ol>
+      </p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -60,24 +77,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m> A = \left[\begin{array}{rrr}
-	  1 \amp 2 \amp -1 \\
-	  3 \amp 2 \amp 2 \\
-	  -1 \amp 0 \amp 4 \\
-	  \end{array}\right]</m>
-	  and <m>\bvec=\threevec{1}{7}{-3}</m>.
-	</p></li>
 
-	<li><p>
-	  There is a unique solution <m>\xvec=\threevec{3}{-1}{0}</m>. 
-	</p></li>
-      </ol>
-      </p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -89,18 +89,18 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+      <m>\xvec\in\real^{2201}</m> and <m>A\xvec\in\real^{135}</m>.
+      </p>
+    </answer>
     <solution>
       <p> If <m>A\xvec</m> is defined, then
       <m>\xvec\in\real^{2201}</m> and <m>A\xvec\in\real^{135}</m>.
       </p>
     </solution>
 
-    <answer>
-      <p>
-      <m>\xvec\in\real^{2201}</m> and <m>A\xvec\in\real^{135}</m>.
-      </p>
-    </answer>
-    
+
   </exercise>
 
   <exercise>
@@ -132,6 +132,28 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Both <m>\vvec_1</m> and <m>\vvec_2</m> are
+	three-dimensional.
+	</p></li>
+
+	<li><p>
+	  <m>A\twovec{1}{0} = \vvec_1</m> and
+	  <m>A\twovec{0}{1} = \vvec_2</m>.  Also,
+	  <m>A\twovec{2}{3} = 2\vvec_1+3\vvec_3</m>.
+	</p></li>
+
+	<li><p>
+	  <m>A = \left[\begin{array}{rr}
+	  3 \amp 0 \\
+	  -2 \amp 3 \\
+	  1 \amp 2 \\
+	  \end{array}\right]
+	  </m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Both <m>\vvec_1</m> and <m>\vvec_2</m> are
@@ -155,29 +177,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Both <m>\vvec_1</m> and <m>\vvec_2</m> are
-	three-dimensional.
-	</p></li>
 
-	<li><p>
-	  <m>A\twovec{1}{0} = \vvec_1</m> and 
-	  <m>A\twovec{0}{1} = \vvec_2</m>.  Also,
-	  <m>A\twovec{2}{3} = 2\vvec_1+3\vvec_3</m>.
-	</p></li>
-
-	<li><p>
-	  <m>A = \left[\begin{array}{rr}
-	  3 \amp 0 \\
-	  -2 \amp 3 \\
-	  1 \amp 2 \\
-	  \end{array}\right]
-	  </m>
-	</p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
   
   <exercise>
@@ -227,6 +227,32 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>A</m> is a <m>2\times2</m> matrix.
+	</p></li>
+
+	<li><p> We have</p>
+	<figure>
+          <caption>The matrix-vector products</caption>
+	  <image width="50%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-matrix-cols-sol-2-2-b">
+              <xi:include href="prefigure/ex-matrix-cols-sol-2-2.xml"/>
+            </prefigure>
+          </image>
+	</figure>
+	</li>
+
+	<li><p>
+	  There is a unique vector <m>\xvec=\twovec{-3}{-3}</m>.
+	</p></li>
+
+	<li><p>
+	  There is a unique vector <m>\xvec=\twovec{0}{0}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> <m>A</m> is a <m>2\times2</m> matrix.
@@ -254,33 +280,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>A</m> is a <m>2\times2</m> matrix.
-	</p></li>
-	
-	<li><p> We have</p>
-	<figure>
-          <caption>The matrix-vector products</caption>
-	  <image width="50%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-matrix-cols-sol-2-2-b">
-              <xi:include href="prefigure/ex-matrix-cols-sol-2-2.xml"/>
-            </prefigure>
-          </image>
-	</figure>
-	</li>
 
-	<li><p>
-	  There is a unique vector <m>\xvec=\twovec{-3}{-3}</m>.
-	</p></li>
-
-	<li><p>
-	  There is a unique vector <m>\xvec=\twovec{0}{0}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -302,6 +302,26 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	  \xvec=\threevec{-2x_3}{x_3}{x_3} = x_3\threevec{-2}{1}{1}\text{.}
+	  </m>
+	</p></li>
+
+	<li><p>
+	  There are many possibilities.  For instance,
+	  <m>
+	    B = \left[\begin{array}{rr}
+	    -2 \amp 2 \\
+	    1 \amp -1 \\
+	    1 \amp -1 \\
+	    \end{array}\right]\text{.}
+	  </m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We construct the augmented matrix
@@ -337,27 +357,7 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>
-	  \xvec=\threevec{-2x_3}{x_3}{x_3} = x_3\threevec{-2}{1}{1}\text{.}
-	  </m>
-	</p></li>
 
-	<li><p>
-	  There are many possibilities.  For instance,
-	  <m>
-	    B = \left[\begin{array}{rr}
-	    -2 \amp 2 \\
-	    1 \amp -1 \\
-	    1 \amp -1 \\
-	    \end{array}\right]\text{.}
-	  </m>
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -401,6 +401,38 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>A\xvec = \threevec{-11}{-2}{13}</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\xvec=\fourvec{9-2x_4}{-1+x_4}{2-x_4}{x_4}
+	  =\fourvec{9}{-1}{2}{0}+x_4\fourvec{-2}{1}{-1}{1}</m>.
+	</p></li>
+
+	<li><p>
+	  We see that
+	  <m>A \sim \left[\begin{array}{rrrr}
+	    {\mathbf 1} \amp 0 \amp 0 \amp 2 \\
+	    0 \amp {\mathbf 1} \amp 0 \amp -1 \\
+	    0 \amp 0 \amp {\mathbf 1} \amp 1 \\
+	    \end{array}\right]\text{.}
+	  </m>
+	</p></li>
+
+	<li><p>
+	  No
+	</p></li>
+
+	<li><p>
+	  The solution space will form a line in
+	  <m>\real^4</m>, as in part b.
+	</p></li>
+
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -453,39 +485,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>A\xvec = \threevec{-11}{-2}{13}</m>.
-	</p></li>
 
-	<li><p>
-	  <m>\xvec=\fourvec{9-2x_4}{-1+x_4}{2-x_4}{x_4}
-	  =\fourvec{9}{-1}{2}{0}+x_4\fourvec{-2}{1}{-1}{1}</m>.
-	</p></li>
-
-	<li><p>
-	  We see that
-	  <m>A \sim \left[\begin{array}{rrrr}
-	    {\mathbf 1} \amp 0 \amp 0 \amp 2 \\
-	    0 \amp {\mathbf 1} \amp 0 \amp -1 \\
-	    0 \amp 0 \amp {\mathbf 1} \amp 1 \\
-	    \end{array}\right]\text{.}
-	  </m>
-	</p></li>
-
-	<li><p>
-	  No
-	</p></li>
-
-	<li><p>
-	  The solution space will form a line in
-	  <m>\real^4</m>, as in part b.
-	</p></li>
-
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -557,6 +557,53 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  To scale the third row by <m>-3</m>, we would use the matrix
+	  <m>S=
+	  \left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  0 \amp 1 \amp 0 \\
+	  0 \amp 0 \amp -3 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  To interchange the first and third rows, we would use
+	  <m>P=
+	  \left[\begin{array}{rrr}
+	  0 \amp 0 \amp 1 \\
+	  0 \amp 1 \amp 0 \\
+	  1 \amp 0 \amp 0 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  To multiply the first row by 3 and add to the third row, we
+	  would use
+	  <m>L_2=
+	  \left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  0 \amp 1 \amp 0 \\
+	  3 \amp 0 \amp 1 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>L=
+	  \left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  -2 \amp 1 \amp 0 \\
+	  -1 \amp 2 \amp 1
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -694,55 +741,8 @@
 	</p></li>
 	</ol></p>
     </solution>
-	    
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  To scale the third row by <m>-3</m>, we would use the matrix
-	  <m>S=
-	  \left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\
-	  0 \amp 1 \amp 0 \\
-	  0 \amp 0 \amp -3 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p>
-	  To interchange the first and third rows, we would use
-	  <m>P=
-	  \left[\begin{array}{rrr}
-	  0 \amp 0 \amp 1 \\
-	  0 \amp 1 \amp 0 \\
-	  1 \amp 0 \amp 0 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p>
-	  To multiply the first row by 3 and add to the third row, we
-	  would use
-	  <m>L_2=
-	  \left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\
-	  0 \amp 1 \amp 0 \\
-	  3 \amp 0 \amp 1 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>L=
-	  \left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\
-	  -2 \amp 1 \amp 0 \\
-	  -1 \amp 2 \amp 1
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-	</ol></p>
-    </answer>
-	    
   </exercise>
 	
   <exercise>
@@ -815,6 +815,31 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	    B = \left[
+	    \begin{array}{rr}
+	    -1 \amp -2 \\
+	    -2 \amp -3 \\
+	    \end{array}\right]\text{.}
+	  </m>
+	</p></li>
+
+	<li><p> It is true, in this case, that <m>AB=BA=I</m>.
+	</p></li>
+
+	<li><p>
+	  <m>I\xvec = \xvec</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\xvec=B\bvec=\twovec{-1}{-4}</m>.
+	</p></li>
+
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -850,32 +875,7 @@
 	</ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>
-	    B = \left[
-	    \begin{array}{rr}
-	    -1 \amp -2 \\
-	    -2 \amp -3 \\
-	    \end{array}\right]\text{.}
-	  </m>
-	</p></li>
 
-	<li><p> It is true, in this case, that <m>AB=BA=I</m>.
-	</p></li>
-
-	<li><p>
-	  <m>I\xvec = \xvec</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\xvec=B\bvec=\twovec{-1}{-4}</m>.
-	</p></li>
-
-	</ol></p>
-    </answer>
-    
   </exercise>
   
   <exercise>
@@ -914,6 +914,15 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False</p></li>
+	<li><p> True </p></li>
+	<li><p> False</p></li>
+	<li><p> True</p></li>
+	<li><p> True</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -952,16 +961,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False</p></li>
-	<li><p> True </p></li>
-	<li><p> False</p></li>
-	<li><p> True</p></li>
-	<li><p> True</p></li>
-      </ol></p>
-    </answer>
-    
+
   </exercise>
 
   <exercise>
@@ -993,6 +993,26 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>A \sim \left[\begin{array}{rrrr}
+	  1 \amp 0 \amp 0 \amp 0 \\
+	  0 \amp 1 \amp 0 \amp 0 \\
+	  0 \amp 0 \amp 1 \amp 0 \\
+	  0 \amp 0 \amp 0 \amp 1 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p> No </p></li>
+
+	<li><p> <m>\xvec=\zerovec</m>. </p></li>
+
+	<li><p> Every equation <m>A\xvec=\bvec</m> has exactly one
+	solution. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Since the solution is unique, there must be a pivot
@@ -1024,27 +1044,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>A \sim \left[\begin{array}{rrrr}
-	  1 \amp 0 \amp 0 \amp 0 \\
-	  0 \amp 1 \amp 0 \amp 0 \\
-	  0 \amp 0 \amp 1 \amp 0 \\
-	  0 \amp 0 \amp 0 \amp 1 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p> No </p></li>
-
-	<li><p> <m>\xvec=\zerovec</m>. </p></li>
-
-	<li><p> Every equation <m>A\xvec=\bvec</m> has exactly one
-	solution. </p></li>
-      </ol></p>
-    </answer>
-      
   </exercise>
 
   <exercise>
@@ -1108,6 +1108,23 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>\xvec = x_3\threevec{-2}{-1}{1}</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\xvec=\threevec{1}{-2}{0}+x_3\threevec{-2}{-1}{1}</m>.
+	</p></li>
+
+	<li><p>
+	  Notice that
+	  <m>A(\xvec_h + \xvec_p) = A\xvec_h + A\xvec_p = \zerovec +
+	  \bvec = \bvec</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have the augmented matrix
@@ -1160,25 +1177,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>\xvec = x_3\threevec{-2}{-1}{1}</m>.
-	</p></li>
 
-	<li><p>
-	  <m>\xvec=\threevec{1}{-2}{0}+x_3\threevec{-2}{-1}{1}</m>.
-	</p></li>
 
-	<li><p>
-	  Notice that
-	  <m>A(\xvec_h + \xvec_p) = A\xvec_h + A\xvec_p = \zerovec +
-	  \bvec = \bvec</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
       
   <exercise>
@@ -1255,6 +1255,27 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> We see that
+	<ol marker="1.">
+	  <li><p> <m>x_2 = \twovec{800}{200}</m>. </p></li>
+	  <li><p> <m>x_2 = \twovec{500}{500}</m>. </p></li>
+	</ol>
+	</p></li>
+
+	<li><p>
+	  <m>\xvec = \twovec{1000}{500}</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\twovec{650}{350}</m> represents the distribution of bicycles
+	on Tuesday, <m>\twovec{695}{305}</m>
+	represents the distribution of bicycles on Wednesday, and
+	<m>\twovec{708.5}{291.5}</m> on Thursday.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We see that
@@ -1278,29 +1299,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> We see that
-	<ol marker="1.">
-	  <li><p> <m>x_2 = \twovec{800}{200}</m>. </p></li>
-	  <li><p> <m>x_2 = \twovec{500}{500}</m>. </p></li>
-	</ol>
-	</p></li>
 
-	<li><p> 
-	  <m>\xvec = \twovec{1000}{500}</m>.
-	</p></li>
 
-	<li><p> 
-	  <m>\twovec{650}{350}</m> represents the distribution of bicycles
-	on Tuesday, <m>\twovec{695}{305}</m>
-	represents the distribution of bicycles on Wednesday, and
-	<m>\twovec{708.5}{291.5}</m> on Thursday.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -1352,63 +1352,6 @@
       </ol></p>
 	    
     </statement>
-
-  <solution>
-    <p><ol marker="a.">
-      <li><p>
-	<m>A\vvec_1 = \twovec{5}{2} = \vvec_1</m> and
-	<m>A\vvec_2 = \twovec{-0.3}{0.3} = 0.3\vvec_2</m>.
-      </p></li>
-
-      <li><p> We have
-      <md>
-	\begin{array}{rl}
-	\xvec_2=A\xvec_1 = \amp A(c_1\vvec_1+c_2\vvec_2) \\
-	=\amp c_1A\vvec_1 + c_2A\vvec_2 =
-	c_1\vvec_1 +0.3c_2\vvec_2\text{.}
-	\end{array}
-      </md>
-      </p></li>
-
-      <li><p>
-	<md>
-	  \begin{array}{rl}
-	\xvec_3=A\xvec_2=\amp A(c_1\vvec_1+0.3c_2\vvec_2) \\
-	= \amp c_1A\vvec_1 -0.3c_2A\vvec_2 =
-	c_1\vvec_1 +0.3^2c_2\vvec_2\text{.}
-	\end{array}
-	</md>
-	and so on.
-      </p></li>
-
-      <li><p>
-	We find that
-	<md>\xvec_1=\twovec{500}{500} = \frac{1000}{7}\vvec_1 +
-	\frac{1500}{7}\vvec_2</md>.
-      </p></li>
-
-      <li><p>
-	Then
-	<md>
-	  \begin{array}{l}
-	  \xvec_2=\frac{1000}{7}\vvec_1 + 0.3\frac{1500}{7}\vvec{2},
-	  \\
-	  \xvec_3=\frac{1000}{7}\vvec_1 + 0.3^2\frac{1500}{7}\vvec{2},
-	  \\
-	  \xvec_4=\frac{1000}{7}\vvec_1 +
-	  0.3^3\frac{1500}{7}\vvec{2}\text{.}
-	  \end{array}
-	  </md>
-      </p></li>
-
-      <li><p> After a very long time, the second term becomes
-      increasingly close to zero and so
-      <md>\xvec\approx\frac{1000}{7}\vvec_1 = \twovec{5000/7}{2000/7}
-      = \twovec{714.3}{285.7}\text{.}
-      </md>
-      </p></li>
-    </ol></p>
-  </solution>
 
   <answer>
     <p><ol marker="a.">
@@ -1466,6 +1409,63 @@
       </p></li>
     </ol></p>
   </answer>
+  <solution>
+    <p><ol marker="a.">
+      <li><p>
+	<m>A\vvec_1 = \twovec{5}{2} = \vvec_1</m> and
+	<m>A\vvec_2 = \twovec{-0.3}{0.3} = 0.3\vvec_2</m>.
+      </p></li>
+
+      <li><p> We have
+      <md>
+	\begin{array}{rl}
+	\xvec_2=A\xvec_1 = \amp A(c_1\vvec_1+c_2\vvec_2) \\
+	=\amp c_1A\vvec_1 + c_2A\vvec_2 =
+	c_1\vvec_1 +0.3c_2\vvec_2\text{.}
+	\end{array}
+      </md>
+      </p></li>
+
+      <li><p>
+	<md>
+	  \begin{array}{rl}
+	\xvec_3=A\xvec_2=\amp A(c_1\vvec_1+0.3c_2\vvec_2) \\
+	= \amp c_1A\vvec_1 -0.3c_2A\vvec_2 =
+	c_1\vvec_1 +0.3^2c_2\vvec_2\text{.}
+	\end{array}
+	</md>
+	and so on.
+      </p></li>
+
+      <li><p>
+	We find that
+	<md>\xvec_1=\twovec{500}{500} = \frac{1000}{7}\vvec_1 +
+	\frac{1500}{7}\vvec_2</md>.
+      </p></li>
+
+      <li><p>
+	Then
+	<md>
+	  \begin{array}{l}
+	  \xvec_2=\frac{1000}{7}\vvec_1 + 0.3\frac{1500}{7}\vvec{2},
+	  \\
+	  \xvec_3=\frac{1000}{7}\vvec_1 + 0.3^2\frac{1500}{7}\vvec{2},
+	  \\
+	  \xvec_4=\frac{1000}{7}\vvec_1 +
+	  0.3^3\frac{1500}{7}\vvec{2}\text{.}
+	  \end{array}
+	  </md>
+      </p></li>
+
+      <li><p> After a very long time, the second term becomes
+      increasingly close to zero and so
+      <md>\xvec\approx\frac{1000}{7}\vvec_1 = \twovec{5000/7}{2000/7}
+      = \twovec{714.3}{285.7}\text{.}
+      </md>
+      </p></li>
+    </ol></p>
+  </solution>
+
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises2-3.xml
+++ b/src/exercises/exercises2-3.xml
@@ -55,6 +55,32 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\laspan{\vvec_1,\vvec_2} = \real^2</m>.
+	</p></li>
+
+	<li><p> For the following vectors,
+	<ol marker="1.">
+	  <li><p> <m>\bvec</m> is in
+	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m>.
+	  </p></li>
+
+	  <li><p> <m>\vvec_3</m> is in
+	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m>.
+	  </p></li>
+
+	  <li><p> <m>\bvec</m> is not in
+	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m>.
+	  </p></li>
+
+	  <li><p> <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m> is a plane in
+	  <m>\real^3</m>.
+	  </p></li>
+	</ol></p></li>
+
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The equation
@@ -98,33 +124,7 @@
 	</li></ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\laspan{\vvec_1,\vvec_2} = \real^2</m>.
-	</p></li>
 
-	<li><p> For the following vectors,
-	<ol marker="1.">
-	  <li><p> <m>\bvec</m> is in
-	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m>.
-	  </p></li>
-
-	  <li><p> <m>\vvec_3</m> is in
-	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m>.
-	  </p></li>
-
-	  <li><p> <m>\bvec</m> is not in
-	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m>.
-	  </p></li>
-
-	  <li><p> <m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m> is a plane in
-	  <m>\real^3</m>.
-	  </p></li>
-	</ol></p></li>
-
-	</ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -150,6 +150,22 @@
 	
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  Yes
+	</p></li>
+
+	<li><p>
+	  Yes
+	</p></li>
+
+	<li><p>
+	  <m>\laspan{\zerovec,\zerovec,\ldots,\zerovec}</m> consists
+	  only of the vector <m>\zerovec</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -168,24 +184,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  Yes
-	</p></li>
 
-	<li><p>
-	  Yes
-	</p></li>
 
-	<li><p>
-	  <m>\laspan{\zerovec,\zerovec,\ldots,\zerovec}</m> consists
-	  only of the vector <m>\zerovec</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -221,6 +221,17 @@
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>\bvec</m> must be a scalar multiple of
+	  <m>\twovec{3}{-2}</m>.
+	</p></li>
+	<li><p>
+	  <m>\bvec</m> can be any vector in <m>\real^2</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -256,18 +267,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>\bvec</m> must be a scalar multiple of
-	  <m>\twovec{3}{-2}</m>.
-	</p></li>
-	<li><p>
-	  <m>\bvec</m> can be any vector in <m>\real^2</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	    
+
   </exercise>
   
   <exercise>
@@ -295,6 +295,12 @@
       </sage>
     </statement>
 
+    <answer>
+      <p>
+	The columns of <m>A</m> do not span <m>\real^4</m>.  The
+	columns of <m>B</m> do.
+      </p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The reduced row echelon form of <m>A</m> is
@@ -337,13 +343,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p>
-	The columns of <m>A</m> do not span <m>\real^4</m>.  The
-	columns of <m>B</m> do.
-      </p>
-    </answer>
-	  
+
   </exercise>
       
   <exercise>
@@ -388,6 +388,15 @@
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li> <p> True  </p></li>
+	<li> <p> True  </p></li>
+	<li> <p> False  </p></li>
+	<li> <p> True  </p></li>
+	<li> <p> False  </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -415,15 +424,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li> <p> True  </p></li>
-	<li> <p> True  </p></li>
-	<li> <p> False  </p></li>
-	<li> <p> True  </p></li>
-	<li> <p> False  </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -444,6 +444,37 @@
 	    
     </statement>
 
+    <answer>
+      <p> We will choose matrices in reduced row echelon form.
+	<ol marker="a.">
+	<li><p>
+	  <m>\left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  0 \amp 1 \amp 0 \\
+	  0 \amp 0 \amp 1 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>\left[\begin{array}{rrr}
+	  1 \amp 0 \amp -2 \\
+	  0 \amp 1 \amp 1 \\
+	  0 \amp 0 \amp 0 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>\left[\begin{array}{rrr}
+	  1 \amp 3 \amp -1 \\
+	  0 \amp 0 \amp 0 \\
+	  0 \amp 0 \amp 0 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p> We will choose matrices in reduced row echelon form.
 	<ol marker="a.">
@@ -476,38 +507,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p> We will choose matrices in reduced row echelon form.
-	<ol marker="a.">
-	<li><p>
-	  <m>\left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\
-	  0 \amp 1 \amp 0 \\
-	  0 \amp 0 \amp 1 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p>
-	  <m>\left[\begin{array}{rrr}
-	  1 \amp 0 \amp -2 \\
-	  0 \amp 1 \amp 1 \\
-	  0 \amp 0 \amp 0 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>\left[\begin{array}{rrr}
-	  1 \amp 3 \amp -1 \\
-	  0 \amp 0 \amp 0 \\
-	  0 \amp 0 \amp 0 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -553,6 +553,15 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Yes </p></li>
+	<li><p> No </p></li>
+	<li><p> Yes </p></li>
+	<li><p> <m>n\geq 438</m> </p></li>
+	<li><p> No </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -588,15 +597,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Yes </p></li>
-	<li><p> No </p></li>
-	<li><p> Yes </p></li>
-	<li><p> <m>n\geq 438</m> </p></li>
-	<li><p> No </p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -628,6 +628,21 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>3\times5</m>
+	</p></li>
+
+	<li><p>
+	  No
+	</p></li>
+
+	<li><p>
+	  Yes
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> <m>AB</m> is a <m>3\times5</m> matrix. </p></li>
@@ -652,21 +667,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>3\times5</m>
-	</p></li>
-
-	<li><p>
-	  No
-	</p></li>
-
-	<li><p>
-	  Yes
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
   
@@ -695,6 +695,19 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> There is a pivot position in each row and each column.
+	</p></li>
+
+	<li><p> The span is <m>\real^{12}</m>. </p></li>
+
+	<li><p> There is a unique solution. </p></li>
+
+	<li><p> There is a unique solution <m>\xvec=\zerovec.</m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Since the solution is unique, each column of <m>A</m>
@@ -717,20 +730,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> There is a pivot position in each row and each column.
-	</p></li>
 
-	<li><p> The span is <m>\real^{12}</m>. </p></li>
-
-	<li><p> There is a unique solution. </p></li>
-	
-	<li><p> There is a unique solution <m>\xvec=\zerovec.</m>
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -764,6 +764,28 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Yes </p></li>
+
+	<li><p> We have
+	<md>
+	  \begin{array}{rl}
+	  a\vvec_1+b\vvec_2+c\vvec_3 \amp = a\vvec_1 +
+	  b\vvec_2+c(-\vvec_1+2\vvec_2) \\
+	  \amp =
+	  (a-c)\vvec_1+(b+2c)\vvec_2\text{.}
+	  \end{array}
+	</md>
+	</p></li>
+
+	<li><p> As seen in the last part of this problem, every linear
+	combination of <m>\vvec_1</m>, <m>\vvec_2</m>, and
+	<m>\vvec_3</m> can be rewritten as a linear combination of
+	<m>\vvec_1</m> and <m>\vvec_2</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Yes, because
@@ -788,28 +810,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Yes </p></li>
-
-	<li><p> We have
-	<md>
-	  \begin{array}{rl}
-	  a\vvec_1+b\vvec_2+c\vvec_3 \amp = a\vvec_1 +
-	  b\vvec_2+c(-\vvec_1+2\vvec_2) \\
-	  \amp =
-	  (a-c)\vvec_1+(b+2c)\vvec_2\text{.}
-	  \end{array}
-	</md>
-	</p></li>
-
-	<li><p> As seen in the last part of this problem, every linear
-	combination of <m>\vvec_1</m>, <m>\vvec_2</m>, and
-	<m>\vvec_3</m> can be rewritten as a linear combination of
-	<m>\vvec_1</m> and <m>\vvec_2</m>.
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -875,6 +875,22 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	<m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m> is the plane defined by
+	<m>\vvec_1</m> and <m>\vvec_2</m>.
+	</p></li>
+
+	<li><p>
+	  <m>2a-4b+c=0</m>.
+	</p></li>
+
+	<li><p> There would be two equations involving
+	the variables <m>a</m>, <m>b</m>, and <m>c</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Finding the reduced row echelon form
@@ -923,24 +939,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	    
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	<m>\laspan{\vvec_1,\vvec_2,\vvec_3}</m> is the plane defined by
-	<m>\vvec_1</m> and <m>\vvec_2</m>.
-	</p></li>
 
-	<li><p>
-	  <m>2a-4b+c=0</m>.
-	</p></li>
 
-	<li><p> There would be two equations involving
-	the variables <m>a</m>, <m>b</m>, and <m>c</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	    
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises2-4.xml
+++ b/src/exercises/exercises2-4.xml
@@ -40,6 +40,26 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  Four vectors in <m>\real^3</m> must always be linearly
+	  dependent.
+	</p></li>
+
+	<li><p>
+	  <m>\vvec_3 = 2\vvec_1-\vvec_2</m>.
+	</p></li>
+
+	<li><p>
+	  <m>c_1=-2</m>, <m>c_2=1</m>, <m>c_3=1</m>, and <m>c_4=0</m>
+	</p></li>
+
+	<li><p>
+	  <m>\xvec = \fourvec{-2}{1}{1}{0}</m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -97,26 +117,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  Four vectors in <m>\real^3</m> must always be linearly
-	  dependent.
-	</p></li>
-
-	<li><p>
-	  <m>\vvec_3 = 2\vvec_1-\vvec_2</m>.
-	</p></li>
-
-	<li><p>
-	  <m>c_1=-2</m>, <m>c_2=1</m>, <m>c_3=1</m>, and <m>c_4=0</m>
-	</p></li>
-
-	<li><p>
-	  <m>\xvec = \fourvec{-2}{1}{1}{0}</m>
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -154,6 +154,29 @@
 	
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  Linearly independent.
+	</p></li>
+
+	<li><p>
+	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3} = \real^3</m>.
+	</p></li>
+
+	<li><p>
+	  Because <m>\laspan{\vvec_1,\vvec_2,\vvec_3} = \real^3</m>,
+	  every vector in <m>\real^3</m> can be written as a linear
+	  combination of <m>\vvec_1</m>, <m>\vvec_2</m>, and
+	  <m>\vvec_3</m>.
+	</p></li>
+
+	<li><p>
+	  In exactly one way.
+	</p></li>
+
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -195,29 +218,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  Linearly independent.
-	</p></li>
-
-	<li><p>
-	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3} = \real^3</m>.
-	</p></li>
-
-	<li><p>
-	  Because <m>\laspan{\vvec_1,\vvec_2,\vvec_3} = \real^3</m>,
-	  every vector in <m>\real^3</m> can be written as a linear
-	  combination of <m>\vvec_1</m>, <m>\vvec_2</m>, and
-	  <m>\vvec_3</m>.
-	</p></li>
-
-	<li><p>
-	  In exactly one way.  
-	</p></li>
-
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -249,6 +249,21 @@
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  Yes
+	</p></li>
+
+	<li><p>
+	  Any subset is linearly independent.
+	</p></li>
+
+	<li><p> They form a linearly independent set.
+	</p></li>
+
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -281,22 +296,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  Yes
-	</p></li>
 
-	<li><p>
-	  Any subset is linearly independent.
-	</p></li>
-
-	<li><p> They form a linearly independent set.
-	</p></li>
-
-	</ol></p>
-    </answer>
-	
   </exercise>
   
   <exercise>
@@ -328,6 +328,15 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -365,15 +374,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -404,6 +404,28 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>\xvec=\fourvec{2}{-1}{3}{1}</m>
+	</p></li>
+
+	<li><p>
+	  There are infinitely many solutions to the homogeneous
+	  equation <m>A\xvec=\zerovec</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\vvec_4 = -2\vvec_1 + \vvec_2 - 3\vvec_3</m>.
+	</p></li>
+
+	<li><p>
+	  One vector can be written as a linear combination of the
+	  others.
+	</p></li>
+
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -430,29 +452,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>\xvec=\fourvec{2}{-1}{3}{1}</m>
-	</p></li>
 
-	<li><p>
-	  There are infinitely many solutions to the homogeneous
-	  equation <m>A\xvec=\zerovec</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\vvec_4 = -2\vvec_1 + \vvec_2 - 3\vvec_3</m>.
-	</p></li>
-
-	<li><p>
-	  One vector can be written as a linear combination of the
-	  others.
-	</p></li>
-
-      </ol></p>
-    </answer>
-	
   </exercise>
       
   <exercise>
@@ -481,6 +481,25 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  There must be at least 27 vectors.
+	</p></li>
+
+	<li><p>
+	  There must be at most 27 vectors.
+	</p></li>
+
+	<li><p>
+	  There are exactly 27 vectors.
+	</p></li>
+
+	<li><p>
+	  There is exactly one solution.
+	</p></li>
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -507,26 +526,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  There must be at least 27 vectors.
-	</p></li>
 
-	<li><p>
-	  There must be at most 27 vectors.
-	</p></li>
-
-	<li><p>
-	  There are exactly 27 vectors.
-	</p></li>
-
-	<li><p>
-	  There is exactly one solution.
-	</p></li>
-	</ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -561,6 +561,51 @@
 	  
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrrr}
+	    1 \amp 0 \amp 0 \amp 0 \\
+	    0 \amp 1 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 1 \amp 0 \\
+	    0 \amp 0 \amp 0 \amp 1 \\
+	    0 \amp 0 \amp 0 \amp 0 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrrr}
+	    1 \amp 0 \amp 0 \amp 0 \\
+	    0 \amp 1 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 1 \amp 0 \\
+	    0 \amp 0 \amp 0 \amp 1 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  This is not possible.
+	</p></li>
+
+	<li><p>
+	  This is not possible.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrrrr}
+	    1 \amp 0 \amp 0 \amp 0 \amp -1 \\
+	    0 \amp 1 \amp 0 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 1 \amp 0 \amp -2 \\
+	    0 \amp 0 \amp 0 \amp 1 \amp 4 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>  There must be a pivot position in every column:
@@ -611,51 +656,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrrr}
-	    1 \amp 0 \amp 0 \amp 0 \\
-	    0 \amp 1 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 1 \amp 0 \\
-	    0 \amp 0 \amp 0 \amp 1 \\
-	    0 \amp 0 \amp 0 \amp 0 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-	    
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrrr}
-	    1 \amp 0 \amp 0 \amp 0 \\
-	    0 \amp 1 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 1 \amp 0 \\
-	    0 \amp 0 \amp 0 \amp 1 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-	    
-	<li><p>
-	  This is not possible. 
-	</p></li>
-	    
-	<li><p>
-	  This is not possible. 
-	</p></li>
-	    
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrrrr}
-	    1 \amp 0 \amp 0 \amp 0 \amp -1 \\
-	    0 \amp 1 \amp 0 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 1 \amp 0 \amp -2 \\
-	    0 \amp 0 \amp 0 \amp 1 \amp 4 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
     
   </exercise>
@@ -685,6 +685,16 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> They are linearly dependent.
+	</p></li>
+
+	<li><p>
+	  The columns of <m>B</m> and <m>C</m> are all equal.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -711,16 +721,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> They are linearly dependent.
-	</p></li>
-
-	<li><p>
-	  The columns of <m>B</m> and <m>C</m> are all equal.
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -742,6 +742,12 @@
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>k=3</m>. </p></li>
+	<li><p> <m>k\neq3</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We construct the matrix
@@ -770,13 +776,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>k=3</m>. </p></li>
-	<li><p> <m>k\neq3</m>. </p></li>
-      </ol></p>
-    </answer>
-      
+
   </exercise>
   
   <exercise>
@@ -819,6 +819,28 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Any linear combination of <m>\vvec_1</m>,
+	<m>\vvec_2</m>, and <m>\wvec</m> can be rewritten as a linear
+	combination of <m>\vvec_1</m> and <m>\vvec_2</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3,\vvec_4} =
+	  \laspan{\vvec_1,\vvec_2,\vvec_4}</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3,\vvec_4} =
+	  \laspan{\vvec_1,\vvec_2}</m>.
+	</p></li>
+
+	<li><p>
+	  It is a plane in <m>\real^3</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -867,28 +889,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Any linear combination of <m>\vvec_1</m>,
-	<m>\vvec_2</m>, and <m>\wvec</m> can be rewritten as a linear
-	combination of <m>\vvec_1</m> and <m>\vvec_2</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3,\vvec_4} =
-	  \laspan{\vvec_1,\vvec_2,\vvec_4}</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\laspan{\vvec_1,\vvec_2,\vvec_3,\vvec_4} =
-	  \laspan{\vvec_1,\vvec_2}</m>.
-	</p></li>
-
-	<li><p>
-	  It is a plane in <m>\real^3</m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 

--- a/src/exercises/exercises2-5.xml
+++ b/src/exercises/exercises2-5.xml
@@ -38,6 +38,28 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>	<m>T:\real^3\to\real^3</m> and
+	<m>S:\real^3\to\real^2</m>.
+	</p></li>
+
+	<li><p> <m> \threevec{6}{-1}{-6}</m>. </p></li>
+
+	<li><p> <m> \twovec{-4}{0}</m>. </p></li>
+
+	<li><p> <m>\twovec{7}{-1}</m>. </p></li>
+
+	<li><p>
+	  <m>	\left[
+	  \begin{array}{rrr}
+	  2 \amp -3 \amp -2 \\
+	  5 \amp 6 \amp 6 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Since <m>A</m> is a <m>3\times3</m> matrix, we have
@@ -69,28 +91,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>	<m>T:\real^3\to\real^3</m> and 
-	<m>S:\real^3\to\real^2</m>.
-	</p></li>
-
-	<li><p> <m> \threevec{6}{-1}{-6}</m>. </p></li>
-
-	<li><p> <m> \twovec{-4}{0}</m>. </p></li>
-
-	<li><p> <m>\twovec{7}{-1}</m>. </p></li>
-
-	<li><p> 
-	  <m>	\left[
-	  \begin{array}{rrr}
-	  2 \amp -3 \amp -2 \\
-	  5 \amp 6 \amp 6 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -123,6 +123,19 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>A=\left[\begin{array}{rrr}
+	3 \amp -1 \amp 4 \\
+	0 \amp 5 \amp -1 \\
+	\end{array}\right]</m>.
+	</p></li>
+
+	<li><p>
+	  Because the first component has the term <m>3x_1^4</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The matrix <m>A=\left[\begin{array}{rrr}
@@ -138,20 +151,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>A=\left[\begin{array}{rrr}
-	3 \amp -1 \amp 4 \\
-	0 \amp 5 \amp -1 \\
-	\end{array}\right]</m>.
-	</p></li>
 
-	<li><p>
-	  Because the first component has the term <m>3x_1^4</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -177,6 +177,20 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p><m>\xvec=
+	x_3\threevec{2}{-1}{1}</m>.
+	</p></li>
+
+	<li><p> There are no such vectors. </p></li>
+
+	<li><p>
+	  <m>\xvec=\threevec{-2}{-2}{0} +
+	  x_3\threevec{2}{-1}{1}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have <m>T(\xvec) = A\xvec = \zerovec</m>.  The
@@ -227,20 +241,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p><m>\xvec=
-	x_3\threevec{2}{-1}{1}</m>.
-	</p></li>
-
-	<li><p> There are no such vectors. </p></li>
-
-	<li><p> 
-	  <m>\xvec=\threevec{-2}{-2}{0} +
-	  x_3\threevec{2}{-1}{1}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -289,6 +289,19 @@
 	</ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\twovec{1}{-1}</m>.
+	</p></li>
+
+	<li><p> <m>\vvec_2</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\xvec=x_3\threevec{1}{1}{1}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> <m>T\left(\threevec{2}{1}{2}\right) =
@@ -319,20 +332,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\twovec{1}{-1}</m>.
-	</p></li>
 
-	<li><p> <m>\vvec_2</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\xvec=x_3\threevec{1}{1}{1}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -442,6 +442,73 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    We have <m>
+		      T(\xvec) =
+		      \threevec{10x_1+20x_2}{50x_1+20x_2}{30x_1+30x_2}
+		    </m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>10x_1 + 20x_2</m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    Bakery 1 makes 10 cakes per hour and Bakery 2 makes 20.
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m>
+		      0.6x_1 + 0.7x_2
+		    </m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>
+		      0.4x_1 + 0.3x_2
+		    </m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>
+		      T(\xvec) = \twovec{0.6x_1+0.7x_2}{0.4x_1+0.3x_2}
+		    </m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		  <m>A =
+		  \begin{bmatrix}
+		  0.6 \amp 0.7 \\
+		  0.4 \amp 0.3 \\
+		  \end{bmatrix}
+		  </m>.
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -537,73 +604,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    We have <m>
-		      T(\xvec) = 
-		      \threevec{10x_1+20x_2}{50x_1+20x_2}{30x_1+30x_2}
-		    </m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>10x_1 + 20x_2</m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    Bakery 1 makes 10 cakes per hour and Bakery 2 makes 20.
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    <m>
-		      0.6x_1 + 0.7x_2
-		    </m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>
-		      0.4x_1 + 0.3x_2
-		    </m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>
-		      T(\xvec) = \twovec{0.6x_1+0.7x_2}{0.4x_1+0.3x_2}
-		    </m>.
-		  </p>
-		</li>
-		<li>
-		  <p> 
-		  <m>A = 
-		  \begin{bmatrix}
-		  0.6 \amp 0.7 \\
-		  0.4 \amp 0.3 \\
-		  \end{bmatrix}
-		  </m>.
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
 
   </exercise>
 		    
@@ -636,6 +636,14 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> False.  The dimensions of <m>A</m> are
@@ -657,14 +665,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -718,6 +718,35 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	<m>A = \left[\begin{array}{rrr}
+	20 \amp 30 \amp 0 \\
+	15 \amp 5 \amp 40 \\
+	\end{array}\right]</m>.
+	</p></li>
+
+	<li><p>
+	<m> B = \left[\begin{array}{rr}
+	5 \amp 6 \\
+	8 \amp 10 \\
+	\end{array}\right]</m>.
+	</p></li>
+
+	<li><p> <m>\twovec{M}{Y}=T\left(\threevec{30}{20}{10}\right) =
+	\twovec{1200}{950}</m> and
+	<m>\twovec{E}{L}=S\left(T\left(\threevec{30}{20}{10}\right)\right)
+	= \twovec{11700}{19100}</m>.
+	</p></li>
+
+	<li><p> <m>C=BA = \left[\begin{array}{rrr}
+	190 \amp 180 \amp 240 \\
+	310 \amp 290 \amp 400 \\
+	\end{array}\right]</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The first column of the matrix is
@@ -750,35 +779,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> 
-	<m>A = \left[\begin{array}{rrr}
-	20 \amp 30 \amp 0 \\
-	15 \amp 5 \amp 40 \\
-	\end{array}\right]</m>.
-	</p></li>
-
-	<li><p> 
-	<m> B = \left[\begin{array}{rr}
-	5 \amp 6 \\
-	8 \amp 10 \\
-	\end{array}\right]</m>.
-	</p></li>
-
-	<li><p> <m>\twovec{M}{Y}=T\left(\threevec{30}{20}{10}\right) =
-	\twovec{1200}{950}</m> and 
-	<m>\twovec{E}{L}=S\left(T\left(\threevec{30}{20}{10}\right)\right)
-	= \twovec{11700}{19100}</m>.
-	</p></li>
-
-	<li><p> <m>C=BA = \left[\begin{array}{rrr}
-	190 \amp 180 \amp 240 \\
-	310 \amp 290 \amp 400 \\
-	\end{array}\right]</m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -802,6 +802,28 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	<m>
+	  T\left(\twovec{1}{0}\right) =
+	  \twovec{1}{-2}
+	</m>.
+	</p></li>
+
+	<li><p>
+	  <m>A=\left[\begin{array}{rr}
+	  1 \amp 2 \\
+	  -2 \amp 0 \\
+	  \end{array}\right]</m>.
+	</p></li>
+
+	<li><p> <m>T\left(\twovec{4}{-5}\right)
+	= \twovec{-6}{-8}</m>.
+	</p></li>
+
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We first find weights <m>c</m> and <m>d</m> such that
@@ -846,30 +868,8 @@
 
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> 
-	<m>
-	  T\left(\twovec{1}{0}\right) =
-	  \twovec{1}{-2}
-	</m>.
-	</p></li>
 
-	<li><p> 
-	  <m>A=\left[\begin{array}{rr}
-	  1 \amp 2 \\
-	  -2 \amp 0 \\
-	  \end{array}\right]</m>.
-	</p></li>
 
-	<li><p> <m>T\left(\twovec{4}{-5}\right) 
-	= \twovec{-6}{-8}</m>.
-	</p></li>
-
-      </ol></p>
-    </answer>
-	  
   </exercise>
   
   <exercise>
@@ -912,6 +912,22 @@
 
     </statement>
 
+    <answer>
+      <p>
+      <ol marker="a.">
+	<li><p> <m>\twovec{1.4}{3.1}</m>.
+	</p></li>
+
+	<li><p> <m>\twovec{0.8}{1.2}</m>.
+	</p></li>
+
+	<li><p> <m>\twovec{6.8}{15.9}</m>.
+	</p></li>
+
+	<li><p> <m>\twovec{116.8}{272.5}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p> The initial state is the vector <m>\xvec_0=\twovec{1}{2}</m>.
       <ol marker="a.">
@@ -933,24 +949,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p> 
-      <ol marker="a.">
-	<li><p> <m>\twovec{1.4}{3.1}</m>.
-	</p></li>
 
-	<li><p> <m>\twovec{0.8}{1.2}</m>.
-	</p></li>
 
-	<li><p> <m>\twovec{6.8}{15.9}</m>.
-	</p></li>
-
-	<li><p> <m>\twovec{116.8}{272.5}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -1004,6 +1004,32 @@
       </ol></p>
     </statement>
 
+  <answer>
+    <p><ol marker="a.">
+      <li><p> <m>T\left(\twovec{1000}{0}\right) = \twovec{950}{0}</m>
+      </p></li>
+
+      <li><p> <m>T\left(\twovec{0}{1000}\right) = \twovec{500}{500}</m>
+      </p></li>
+
+      <li><p> <m>A=\left[\begin{array}{rr}0.95 \amp 0.50 \\
+      0.05 \amp 0.50 \\
+      \end{array}\right]</m>.
+      </p></li>
+
+      <li><p> There are 1665 students present and 135 absent.
+      </p></li>
+
+      <li><p> 1778
+      </p></li>
+
+      <li><p> 1636
+      </p></li>
+
+      <li><p> It stabilizes around 1636 students present.
+      </p></li>
+    </ol></p>
+  </answer>
   <solution>
     <p><ol marker="a.">
       <li><p> <m>T\left(\twovec{1000}{0}\right) = \twovec{950}{0}</m>
@@ -1041,32 +1067,6 @@
     </ol></p>
   </solution>
 
-  <answer>
-    <p><ol marker="a.">
-      <li><p> <m>T\left(\twovec{1000}{0}\right) = \twovec{950}{0}</m>
-      </p></li>
-
-      <li><p> <m>T\left(\twovec{0}{1000}\right) = \twovec{500}{500}</m>
-      </p></li>
-
-      <li><p> <m>A=\left[\begin{array}{rr}0.95 \amp 0.50 \\
-      0.05 \amp 0.50 \\
-      \end{array}\right]</m>.
-      </p></li>
-
-      <li><p> There are 1665 students present and 135 absent.
-      </p></li>
-
-      <li><p> 1778
-      </p></li>
-
-      <li><p> 1636
-      </p></li>
-
-      <li><p> It stabilizes around 1636 students present.
-      </p></li>
-    </ol></p>
-  </answer>
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises2-6.xml
+++ b/src/exercises/exercises2-6.xml
@@ -24,6 +24,54 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    -1 \amp 0 \\
+	    0 \amp -1 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    1 \amp 0 \\
+	    0 \amp -1 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    0 \amp -1 \\
+	    -1 \amp 0 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    \frac 12 \amp -\frac{\sqrt{3}}2 \\
+	    \frac{\sqrt{3}}2 \amp \frac12\\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    \frac{\sqrt{3}}2 \amp \frac12\\
+	    \frac 12 \amp -\frac{\sqrt{3}}2 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p> We create the following matrices as <m>\left[\begin{array}{rr}
       T(\evec_1) \amp T(\evec_2) \\ \end{array}\right]</m>.
@@ -89,55 +137,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    -1 \amp 0 \\
-	    0 \amp -1 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-	
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    1 \amp 0 \\
-	    0 \amp -1 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
 
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    0 \amp -1 \\
-	    -1 \amp 0 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-	
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    \frac 12 \amp -\frac{\sqrt{3}}2 \\
-	    \frac{\sqrt{3}}2 \amp \frac12\\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    \frac{\sqrt{3}}2 \amp \frac12\\
-	    \frac 12 \amp -\frac{\sqrt{3}}2 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	    
   </exercise>
 
   <exercise xml:id="ex-compose-reflections">
@@ -171,6 +171,25 @@
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  This is the same as a counterclockwise <m>90^\circ</m> rotation.
+	</p></li>
+
+	<li><p>
+	  This is the same as a clockwise <m>90^\circ</m> rotation.
+	</p></li>
+
+	<li><p>
+	  This is the same as a <m>180^\circ</m> rotation.
+	</p></li>
+
+	<li><p>
+	  This is the same as a reflection in the horizontal axis.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -251,26 +270,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  This is the same as a counterclockwise <m>90^\circ</m> rotation.
-	</p></li>
 
-	<li><p>
-	  This is the same as a clockwise <m>90^\circ</m> rotation.
-	</p></li>
-
-	<li><p>
-	  This is the same as a <m>180^\circ</m> rotation.
-	</p></li>
-
-	<li><p>
-	  This is the same as a reflection in the horizontal axis.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -337,6 +337,46 @@
       </p>
     </statement>
 
+    <answer>
+      <p> <ol marker="a.">
+	<li><p>
+	  <m>\left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  0 \amp 0 \amp -1  \\
+	  0 \amp 1 \amp 0 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>\left[\begin{array}{rrr}
+	  0 \amp 0 \amp 1 \\
+	  0 \amp 1 \amp 0  \\
+	  -1 \amp 0 \amp 0 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>\left[\begin{array}{rrr}
+	  0 \amp -1 \amp 0 \\
+	  1 \amp 0 \amp 0  \\
+	  0 \amp 0 \amp 1 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	  \left[\begin{array}{rrr}
+	  0 \amp 1 \amp 0 \\
+	  -1 \amp 0 \amp 0  \\
+	  0 \amp 0 \amp 1 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p> We construct the matrices as
       <m>\left[\begin{array}{rrr} T(\evec_1) \amp
@@ -396,46 +436,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p> <ol marker="a.">
-	<li><p>
-	  <m>\left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\ 
-	  0 \amp 0 \amp -1  \\
-	  0 \amp 1 \amp 0 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p> 
-	  <m>\left[\begin{array}{rrr}
-	  0 \amp 0 \amp 1 \\ 
-	  0 \amp 1 \amp 0  \\
-	  -1 \amp 0 \amp 0 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>\left[\begin{array}{rrr}
-	  0 \amp -1 \amp 0 \\ 
-	  1 \amp 0 \amp 0  \\
-	  0 \amp 0 \amp 1 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	  \left[\begin{array}{rrr}
-	  0 \amp 1 \amp 0 \\ 
-	  -1 \amp 0 \amp 0  \\
-	  0 \amp 0 \amp 1 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -491,6 +491,47 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    0 \amp 1 \\
+	    -1 \amp 0 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  The square of the matrix
+	  <m>
+	    \left[\begin{array}{rr}
+	    0 \amp 1 \\
+	    1 \amp 0 \\
+	    \end{array}\right]
+	  </m>
+	  is the identity.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    1 \amp -1 \\
+	    0 \amp 1 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    2 \amp 0 \\
+	    0 \amp \frac13 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The transformation <m>S</m> should rotate vectors by
@@ -551,49 +592,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    0 \amp 1 \\
-	    -1 \amp 0 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p>
-	  The square of the matrix
-	  <m>
-	    \left[\begin{array}{rr}
-	    0 \amp 1 \\
-	    1 \amp 0 \\
-	    \end{array}\right]
-	  </m>
-	  is the identity.
-	</p></li>
 
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    1 \amp -1 \\
-	    0 \amp 1 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    2 \amp 0 \\
-	    0 \amp \frac13 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -720,6 +720,53 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    1 \amp 0 \amp -1 \\
+	    0 \amp 1 \amp -2 \\
+	    0 \amp 0 \amp 1 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    0 \amp -1 \amp 0 \\
+	    1 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 1 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    1 \amp 0 \amp 1 \\
+	    0 \amp 1 \amp 2 \\
+	    0 \amp 0 \amp 1 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    0 \amp -1 \amp 3 \\
+	    1 \amp 0 \amp 1 \\
+	    0 \amp 0 \amp 1 \\
+	    \end{array}\right].
+	  </m>
+	</p></li>
+	<li><p>
+	  The point <m>(-10,5)</m> is rotated to
+	  <m>(-2,-9)</m>.
+	</p></li>
+	</ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -786,53 +833,6 @@
 	</ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    1 \amp 0 \amp -1 \\
-	    0 \amp 1 \amp -2 \\
-	    0 \amp 0 \amp 1 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    0 \amp -1 \amp 0 \\
-	    1 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 1 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    1 \amp 0 \amp 1 \\
-	    0 \amp 1 \amp 2 \\
-	    0 \amp 0 \amp 1 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    0 \amp -1 \amp 3 \\
-	    1 \amp 0 \amp 1 \\
-	    0 \amp 0 \amp 1 \\
-	    \end{array}\right].
-	  </m>
-	</p></li>
-	<li><p>
-	  The point <m>(-10,5)</m> is rotated to
-	  <m>(-2,-9)</m>.
-	</p></li>
-	</ol></p>
-    </answer>
 
   </exercise>
       
@@ -908,6 +908,43 @@
       
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>\left[\begin{array}{rr}
+	  1 \amp 0 \\
+	  0 \amp 0 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>\left[\begin{array}{rr}
+	  0 \amp 0 \\
+	  0 \amp 1 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    0 \amp 0 \\
+	    0 \amp 0 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rr}
+	    \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
+	    \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -957,43 +994,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>\left[\begin{array}{rr}
-	  1 \amp 0 \\
-	  0 \amp 0 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>\left[\begin{array}{rr}
-	  0 \amp 0 \\
-	  0 \amp 1 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    0 \amp 0 \\
-	    0 \amp 0 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rr}
-	    \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
-	    \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -1168,6 +1168,50 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  It stretches vectors by <m>r</m>.
+	</p></li>
+
+	<li><p>
+	  This matrix rotates vectors by an angle <m>\theta</m>.
+	</p></li>
+
+	<li><p> No matter which order we multiply the matrices, we
+	find that their product is
+	  <md>
+	    \left[\begin{array}{rr}
+	    r\cos\theta \amp -r\sin\theta \\
+	    r\sin\theta \amp r\sin\theta \\
+	    \end{array}\right]\text{.}
+	  </md>
+	</p></li>
+
+	<li><p>
+	  This follows from the previous part.
+	</p></li>
+
+	<li><p>
+	  If we use polar coordinates to write <m>\twovec{a}{b} =
+	  \twovec{r\cos\theta}{r\sin\theta}</m>, multiplying a
+	  vector by <m>A</m> will stretch the vector by <m>r</m> and
+	  rotate it by <m>\theta</m>.
+	</p></li>
+
+	<li><p>
+	  If
+	  <md>
+	    \twovec{a}{b} =
+	    \twovec{r\cos\theta}{r\sin\theta},
+	    \twovec{c}{d} =
+	    \twovec{s\cos\phi}{s\sin\phi}\text{,}
+	  </md>
+	  then <m>S\circ T</m> has the effect of stretching a vector
+	  by <m>rs</m> and rotating it by <m>\theta + \phi</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -1228,52 +1272,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  It stretches vectors by <m>r</m>.  
-	</p></li>
 
-	<li><p>
-	  This matrix rotates vectors by an angle <m>\theta</m>.
-	</p></li>
 
-	<li><p> No matter which order we multiply the matrices, we
-	find that their product is
-	  <md>
-	    \left[\begin{array}{rr}
-	    r\cos\theta \amp -r\sin\theta \\
-	    r\sin\theta \amp r\sin\theta \\
-	    \end{array}\right]\text{.}
-	  </md>
-	</p></li>
-
-	<li><p>
-	  This follows from the previous part.
-	</p></li>
-
-	<li><p>
-	  If we use polar coordinates to write <m>\twovec{a}{b} =
-	  \twovec{r\cos\theta}{r\sin\theta}</m>, multiplying a
-	  vector by <m>A</m> will stretch the vector by <m>r</m> and
-	  rotate it by <m>\theta</m>.
-	</p></li>
-
-	<li><p>
-	  If
-	  <md>
-	    \twovec{a}{b} =
-	    \twovec{r\cos\theta}{r\sin\theta},
-	    \twovec{c}{d} =
-	    \twovec{s\cos\phi}{s\sin\phi}\text{,}
-	  </md>
-	  then <m>S\circ T</m> has the effect of stretching a vector
-	  by <m>rs</m> and rotating it by <m>\theta + \phi</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise xml:id="ex-reflection-compose-general">
@@ -1436,6 +1436,56 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  We have
+	  <md>
+	    \begin{array}{rl}
+	    \left[\begin{array}{rr}
+	    \cos\theta \amp -\sin\theta \\
+	    \sin\theta \amp \cos\theta \\
+	    \end{array}\right]
+	    \left[\begin{array}{rr}
+	    1 \amp 0 \\
+	    0 \amp -1 \\
+	    \end{array}\right] \amp
+	    \left[\begin{array}{rr}
+	    \cos\theta \amp \sin\theta \\
+	    -\sin\theta \amp \cos\theta \\
+	    \end{array}\right]
+	    \\
+	    =
+	    \amp
+	    \left[\begin{array}{rr}
+	    \cos(2\theta) \amp \sin(2\theta) \\
+	    \sin(2\theta) \amp -\cos(2\theta) \\
+	    \end{array}\right]
+	    \text{.}
+	    \end{array}
+	  </md>
+	</p></li>
+
+	<li><p>
+	  Compute that
+	  <md>
+	    \left[\begin{array}{rr}
+	    \cos(2\theta) \amp \sin(2\theta) \\
+	    \sin(2\theta) \amp -\cos(2\theta) \\
+	    \end{array}\right]
+	    \left[\begin{array}{rr}
+	    1 \amp 0 \\
+	    0 \amp -1 \\
+	    \end{array}\right]
+	    =
+	    \left[\begin{array}{rr}
+	    \cos(2\theta) \amp -\sin(2\theta) \\
+	    \sin(2\theta) \amp \cos(2\theta)
+	    \end{array}\right]\text{.}
+	  </md>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -1501,58 +1551,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	    
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  We have
-	  <md>
-	    \begin{array}{rl}
-	    \left[\begin{array}{rr}
-	    \cos\theta \amp -\sin\theta \\
-	    \sin\theta \amp \cos\theta \\
-	    \end{array}\right]
-	    \left[\begin{array}{rr}
-	    1 \amp 0 \\
-	    0 \amp -1 \\
-	    \end{array}\right] \amp 
-	    \left[\begin{array}{rr}
-	    \cos\theta \amp \sin\theta \\
-	    -\sin\theta \amp \cos\theta \\
-	    \end{array}\right]
-	    \\
-	    =
-	    \amp
-	    \left[\begin{array}{rr}
-	    \cos(2\theta) \amp \sin(2\theta) \\
-	    \sin(2\theta) \amp -\cos(2\theta) \\
-	    \end{array}\right]
-	    \text{.}
-	    \end{array}
-	  </md>
-	</p></li>
 
-	<li><p>
-	  Compute that
-	  <md>
-	    \left[\begin{array}{rr}
-	    \cos(2\theta) \amp \sin(2\theta) \\
-	    \sin(2\theta) \amp -\cos(2\theta) \\
-	    \end{array}\right]
-	    \left[\begin{array}{rr}
-	    1 \amp 0 \\
-	    0 \amp -1 \\
-	    \end{array}\right]
-	    =
-	    \left[\begin{array}{rr}
-	    \cos(2\theta) \amp -\sin(2\theta) \\
-	    \sin(2\theta) \amp \cos(2\theta)
-	    \end{array}\right]\text{.}
-	  </md>
-	</p></li>
-      </ol></p>
-    </answer>
-	    
+
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises3-1.xml
+++ b/src/exercises/exercises3-1.xml
@@ -34,6 +34,31 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>A\sim I</m>
+	</p></li>
+
+	<li><p>
+	  <m>
+	    A^{-1} =
+	    \left[\begin{array}{rrrr}
+              -\frac{1}{2} \amp 0 \amp -\frac{1}{2} \amp \frac{1}{2} \\
+              4 \amp -2 \amp 9 \amp 2 \\
+              -\frac{7}{2} \amp 2 \amp -\frac{15}{2} \amp -\frac{3}{2} \\
+              \frac{5}{2} \amp -1 \amp \frac{9}{2} \amp \frac{1}{2}
+	    \end{array}\right]\text{.}
+	  </m>
+	</p></li>
+
+	<li><p>
+	  <m>\xvec=
+	  \fourvec{-\frac12}{-21}{\frac{35}2}{-\frac{17}{2}}
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -80,32 +105,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>A\sim I</m>
-	</p></li>
 
-	<li><p>
-	  <m>
-	    A^{-1} =
-	    \left[\begin{array}{rrrr}
-              -\frac{1}{2} \amp 0 \amp -\frac{1}{2} \amp \frac{1}{2} \\
-              4 \amp -2 \amp 9 \amp 2 \\
-              -\frac{7}{2} \amp 2 \amp -\frac{15}{2} \amp -\frac{3}{2} \\
-              \frac{5}{2} \amp -1 \amp \frac{9}{2} \amp \frac{1}{2}
-	    \end{array}\right]\text{.}
-	  </m>
-	</p></li>
-
-	<li><p>
-	  <m>\xvec=
-	  \fourvec{-\frac12}{-21}{\frac{35}2}{-\frac{17}{2}}
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -128,6 +128,45 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>A=\left[\begin{array}{rr}
+	  \frac1{\sqrt{2}} \amp -\frac1{\sqrt{2}} \\
+	  \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
+	  \end{array}\right]</m>
+	  and
+	  <m>A^{-1}=\left[\begin{array}{rr}
+	  \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
+	  -\frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
+	  \end{array}\right]</m>.
+	</p></li>
+
+	<li><p>
+	  <m>A=\left[\begin{array}{rr}
+	  -1 \amp 0 \\
+	  0 \amp -1 \\
+	  \end{array}\right]</m>.
+	</p></li>
+
+	<li><p>
+	  <md>
+	    \left[\begin{array}{rr}
+	    1 \amp 0 \\
+	    0 \amp -1 \\
+	    \end{array}\right],
+	    \left[\begin{array}{rr}
+	    -1 \amp 0 \\
+	    0 \amp 1 \\
+	    \end{array}\right],
+	    \left[\begin{array}{rr}
+	    0 \amp 1 \\
+	    1 \amp 0 \\
+	    \end{array}\right]\text{.}
+	  </md>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -172,46 +211,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>A=\left[\begin{array}{rr}
-	  \frac1{\sqrt{2}} \amp -\frac1{\sqrt{2}} \\
-	  \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
-	  \end{array}\right]</m>
-	  and
-	  <m>A^{-1}=\left[\begin{array}{rr}
-	  \frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
-	  -\frac1{\sqrt{2}} \amp \frac1{\sqrt{2}} \\
-	  \end{array}\right]</m>.
-	</p></li>
 
-	<li><p>
-	  <m>A=\left[\begin{array}{rr}
-	  -1 \amp 0 \\
-	  0 \amp -1 \\
-	  \end{array}\right]</m>.  
-	</p></li>
-
-	<li><p>
-	  <md>
-	    \left[\begin{array}{rr}
-	    1 \amp 0 \\
-	    0 \amp -1 \\
-	    \end{array}\right],
-	    \left[\begin{array}{rr}
-	    -1 \amp 0 \\
-	    0 \amp 1 \\
-	    \end{array}\right],
-	    \left[\begin{array}{rr}
-	    0 \amp 1 \\
-	    1 \amp 0 \\
-	    \end{array}\right]\text{.}
-	  </md>
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -282,6 +282,62 @@
       </ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m> D^{-1} = \begin{bmatrix}
+		    \frac12 \amp 0 \amp 0 \\
+		    0 \amp -1 \amp 0 \\
+		    0 \amp 0 \amp \frac14 \\
+		    \end{bmatrix}
+		    </m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    When the entries on the diagonal are all nonzero.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    Consider the steps performed in
+		    row reducing <m>D</m>
+		    augmented by <m>I</m>.
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m>L^{-1} = \begin{bmatrix}
+		    1 \amp 0 \amp 0 \\
+		    2 \amp 1 \amp 0 \\
+		    5 \amp 4 \amp 1
+		    \end{bmatrix}
+		    </m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    Consider the steps in row reducing
+		    <m>L</m> augmented by <m>I</m>.
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -343,62 +399,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    <m> D^{-1} = \begin{bmatrix}
-		    \frac12 \amp 0 \amp 0 \\
-		    0 \amp -1 \amp 0 \\
-		    0 \amp 0 \amp \frac14 \\
-		    \end{bmatrix}
-		    </m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    When the entries on the diagonal are all nonzero.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    Consider the steps performed in 
-		    row reducing <m>D</m>
-		    augmented by <m>I</m>.
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    <m>L^{-1} = \begin{bmatrix}
-		    1 \amp 0 \amp 0 \\
-		    2 \amp 1 \amp 0 \\
-		    5 \amp 4 \amp 1
-		    \end{bmatrix}
-		    </m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    Consider the steps in row reducing
-		    <m>L</m> augmented by <m>I</m>.
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 		
 
@@ -459,6 +459,22 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>BA=I_2</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\xvec= \twovec{2}{-1}</m>
+	</p></li>
+
+	<li><p>
+	  <m>CA=I_2</m>.
+	</p></li>
+
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -478,22 +494,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>BA=I_2</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\xvec= \twovec{2}{-1}</m>
-	</p></li>
-
-	<li><p>
-	  <m>CA=I_2</m>.
-	</p></li>
-
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -547,6 +547,41 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>A^{-1}=
+	  \left[\begin{array}{rrr}
+	  0 \amp -\frac13 \amp 0 \\
+	  \frac12 \amp 0 \amp 0 \\
+	  0 \amp 0 \amp 1 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>A^{-1} =
+	    \left[\begin{array}{rrrr}
+	    1 \amp 0 \amp 0 \amp 0 \\
+	    -2 \amp 1 \amp 0 \amp 0 \\
+	    -6 \amp 3 \amp 1 \amp 0 \\
+	    12 \amp -6 \amp -2 \amp 1 \\
+	    \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>
+	    A^{-1} =
+	    \left[\begin{array}{rrr}
+	    1 \amp -1 \amp 0 \\
+	    0 \amp 1 \amp -\frac12 \\
+	    0 \amp 0 \amp \frac12 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -657,42 +692,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>A^{-1}=
-	  \left[\begin{array}{rrr}
-	  0 \amp -\frac13 \amp 0 \\
-	  \frac12 \amp 0 \amp 0 \\
-	  0 \amp 0 \amp 1 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p>
-	  <m>A^{-1} = 
-	    \left[\begin{array}{rrrr}
-	    1 \amp 0 \amp 0 \amp 0 \\
-	    -2 \amp 1 \amp 0 \amp 0 \\
-	    -6 \amp 3 \amp 1 \amp 0 \\
-	    12 \amp -6 \amp -2 \amp 1 \\
-	    \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p>
-	  <m>
-	    A^{-1} = 
-	    \left[\begin{array}{rrr}
-	    1 \amp -1 \amp 0 \\
-	    0 \amp 1 \amp -\frac12 \\
-	    0 \amp 0 \amp \frac12 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -710,20 +710,6 @@
       </ol></p>
     </statement>
 
-    <solution>
-      <p><ol marker="a.">
-	<li><p>
-	  If <m>A^2</m> has inverse <m>B</m>, then <m>A^2B = I</m>.
-	  This means that <m>A(AB)=I</m> so <m>A</m> is invertible
-	  with inverse <m>AB</m>.
-	</p></li>
-
-	<li><p>
-	  In the same way, we have <m>A^{100}B = A(A^{99}B)=I</m>,
-	  which shows that <m>A^{-1}=A^{99}B</m>.
-	</p></li>
-      </ol></p>
-    </solution>
     <answer>
       <p><ol marker="a.">
 	<li><p>
@@ -738,6 +724,20 @@
 	</p></li>
       </ol></p>
     </answer>
+    <solution>
+      <p><ol marker="a.">
+	<li><p>
+	  If <m>A^2</m> has inverse <m>B</m>, then <m>A^2B = I</m>.
+	  This means that <m>A(AB)=I</m> so <m>A</m> is invertible
+	  with inverse <m>AB</m>.
+	</p></li>
+
+	<li><p>
+	  In the same way, we have <m>A^{100}B = A(A^{99}B)=I</m>,
+	  which shows that <m>A^{-1}=A^{99}B</m>.
+	</p></li>
+      </ol></p>
+    </solution>
   </exercise>
 
   <exercise>
@@ -768,6 +768,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> False</p></li>
+	<li><p> True </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -806,15 +815,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> False</p></li>
-	<li><p> True </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -843,6 +843,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> No </p></li>
+	<li><p> No </p></li>
+	<li><p> Yes </p></li>
+	<li><p> The span is <m>\real^n</m>. </p></li>
+	<li><p> Yes </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -881,15 +890,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> No </p></li>
-	<li><p> No </p></li>
-	<li><p> Yes </p></li>
-	<li><p> The span is <m>\real^n</m>. </p></li>
-	<li><p> Yes </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -934,6 +934,60 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  We have
+	  <md>
+	    \begin{array}{cc}
+	    E_1=\left[\begin{array}{rrr}
+	    1 \amp 0 \amp 0 \\
+	    -2 \amp 1 \amp 0 \\
+	    0 \amp 0 \amp 1
+	    \end{array}\right],
+	    \amp
+	    E_2=\left[\begin{array}{rrr}
+	    1 \amp 0 \amp 0 \\
+	    0 \amp 1 \amp 0 \\
+	    4 \amp 0 \amp 1
+	    \end{array}\right], \\
+	    E_3 = \left[\begin{array}{rrr}
+	    1 \amp 0 \amp 0 \\
+	    0 \amp \frac{1}{2} \amp 0 \\
+	    0 \amp 0 \amp 1
+	    \end{array}\right],
+	    \amp
+	    E_4 =
+	    \left[\begin{array}{rrr}
+	    1 \amp 0 \amp 0 \\
+	    0 \amp 1 \amp 0 \\
+	    0 \amp -2 \amp 1
+	    \end{array}\right]\text{.}
+	    \end{array}
+	  </md>
+	</p></li>
+
+	<li><p>
+	  <m> E =
+	  \left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  -1 \amp \frac{1}{2} \amp 0 \\
+	  6 \amp -1 \amp 1
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p>
+	  <m>A=
+	  \left[\begin{array}{rrr}
+	  3 \amp 2 \amp -1 \\
+	  6 \amp 6 \amp 4 \\
+	  -12 \amp -6 \amp 6
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -989,62 +1043,8 @@
 	</p></li>
       </ol></p>
     </solution>
-    
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  We have
-	  <md>
-	    \begin{array}{cc}
-	    E_1=\left[\begin{array}{rrr}
-	    1 \amp 0 \amp 0 \\
-	    -2 \amp 1 \amp 0 \\
-	    0 \amp 0 \amp 1
-	    \end{array}\right],
-	    \amp
-	    E_2=\left[\begin{array}{rrr}
-	    1 \amp 0 \amp 0 \\
-	    0 \amp 1 \amp 0 \\
-	    4 \amp 0 \amp 1
-	    \end{array}\right], \\
-	    E_3 = \left[\begin{array}{rrr}
-	    1 \amp 0 \amp 0 \\
-	    0 \amp \frac{1}{2} \amp 0 \\
-	    0 \amp 0 \amp 1
-	    \end{array}\right],
-	    \amp
-	    E_4 = 
-	    \left[\begin{array}{rrr}
-	    1 \amp 0 \amp 0 \\
-	    0 \amp 1 \amp 0 \\
-	    0 \amp -2 \amp 1
-	    \end{array}\right]\text{.}
-	    \end{array}
-	  </md>
-	</p></li>
 
-	<li><p>
-	  <m> E = 
-	  \left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\
-	  -1 \amp \frac{1}{2} \amp 0 \\
-	  6 \amp -1 \amp 1
-	  \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p>
-	  <m>A=
-	  \left[\begin{array}{rrr}
-	  3 \amp 2 \amp -1 \\
-	  6 \amp 6 \amp 4 \\
-	  -12 \amp -6 \amp 6
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -1086,6 +1086,32 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>B^2 = PA^2P^{-1}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>B^{-1} = PA^{-1}P^{-1}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>B^{-1}= PA^{-1}P^{-1}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>C = (QP)A(QP)^{-1}</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1113,33 +1139,7 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>B^2 = PA^2P^{-1}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>B^{-1} = PA^{-1}P^{-1}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>B^{-1}= PA^{-1}P^{-1}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>C = (QP)A(QP)^{-1}</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
+
   </exercise>
 	  
   <exercise>
@@ -1204,6 +1204,59 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m>AB\sim I</m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    If <m>B\xvec=\zerovec</m>, then <m>AB\xvec =
+		    \zerovec</m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    We now know that <m>B\sim I</m>.
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    The span of the
+		    columns of <m>AB</m> is <m>\real^n</m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    A solution to
+		    <m>AB\xvec = \bvec</m> produces a solution to
+		    <m>A\xvec = \bvec</m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    The span of the columns of
+		    <m>A</m> is <m>\real^n</m>.
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1270,60 +1323,7 @@
 	</ol>
       </p>
     </solution>
-		    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    <m>AB\sim I</m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    If <m>B\xvec=\zerovec</m>, then <m>AB\xvec =
-		    \zerovec</m>. 
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    We now know that <m>B\sim I</m>.
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    The span of the
-		    columns of <m>AB</m> is <m>\real^n</m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    A solution to 
-		    <m>AB\xvec = \bvec</m> produces a solution to
-		    <m>A\xvec = \bvec</m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    The span of the columns of
-		    <m>A</m> is <m>\real^n</m>.
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
+
   </exercise>
 
   <exercise xml:id="ex-right-inverse">
@@ -1357,6 +1357,24 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  If <m>B\xvec = \zerovec</m>, then <m>AB\xvec = \xvec =
+	  \zerovec</m>.
+	</p></li>
+
+	<li><p>
+	  <m>B</m> is invertible because <m>B\sim I</m>.
+	</p></li>
+
+	<li><p>
+	  Multiply <m>AB=I</m> on the left by <m>B</m> and the right
+	  by <m>C</m> and regroup the matrix multiplications.
+	</p></li>
+
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -1388,24 +1406,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  If <m>B\xvec = \zerovec</m>, then <m>AB\xvec = \xvec =
-	  \zerovec</m>. 
-	</p></li>
-
-	<li><p>
-	  <m>B</m> is invertible because <m>B\sim I</m>.
-	</p></li>
-
-	<li><p> 
-	  Multiply <m>AB=I</m> on the left by <m>B</m> and the right
-	  by <m>C</m> and regroup the matrix multiplications.
-	</p></li>
-
-      </ol></p>
-    </answer>
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises3-2.xml
+++ b/src/exercises/exercises3-2.xml
@@ -60,6 +60,34 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  The vectors are linearly independent and span
+	  <m>\real^2</m>.
+	</p></li>
+
+	<li><p> The grid on the figure indicates that
+	<ol marker="1.">
+	  <li><p> <m>\xvec = \twovec{-6}{3}</m>. </p></li>
+	  <li><p> <m>\xvec = \twovec{-2}{-4}</m>. </p></li>
+	  <li><p> <m>\xvec = \twovec63</m>. </p></li>
+	</ol>
+	</p></li>
+
+	<li><p> The grid on the figure indicates that
+	<ol marker="1.">
+	  <li><p> <m>\coords{\xvec}{\bcal} = \twovec{0}{-1}</m>. </p></li>
+	  <li><p> <m>\coords{\xvec}{\bcal} = \twovec{1}{2}</m>. </p></li>
+	  <li><p> <m>\coords{\xvec}{\bcal} = \twovec{-2}{-1}</m>. </p></li>
+	</ol>
+	</p></li>
+
+	<li><p>
+	  <m>\coords{\xvec}{\bcal} = \twovec{20}{50}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -114,36 +142,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  The vectors are linearly independent and span
-	  <m>\real^2</m>.
-	</p></li>
 
-	<li><p> The grid on the figure indicates that
-	<ol marker="1.">
-	  <li><p> <m>\xvec = \twovec{-6}{3}</m>. </p></li>
-	  <li><p> <m>\xvec = \twovec{-2}{-4}</m>. </p></li>
-	  <li><p> <m>\xvec = \twovec63</m>. </p></li>
-	</ol>
-	</p></li>
 
-	<li><p> The grid on the figure indicates that
-	<ol marker="1.">
-	  <li><p> <m>\coords{\xvec}{\bcal} = \twovec{0}{-1}</m>. </p></li> 
-	  <li><p> <m>\coords{\xvec}{\bcal} = \twovec{1}{2}</m>. </p></li> 
-	  <li><p> <m>\coords{\xvec}{\bcal} = \twovec{-2}{-1}</m>. </p></li>
-	</ol>
-	</p></li>
-
-	<li><p> 
-	  <m>\coords{\xvec}{\bcal} = \twovec{20}{50}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -176,6 +176,36 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> The sets of the vectors are both
+	linearly independent and span <m>\real^2</m>.
+	</p></li>
+
+	<li><p>
+	<m>\coords{\xvec}{\bcal}=\twovec{12/5}{13/5}</m> and
+	<m>\coords{\xvec}{\ccal}=\twovec{13}{21}</m>.
+	</p></li>
+
+	<li><p> <m>\xvec=
+	\twovec{-2}{16}</m> and
+	<m>\coords{\xvec}{\ccal}=\twovec{-20}{-38}</m>.
+	</p></li>
+
+	<li><p> <m>\xvec=\twovec{-8}{-13}</m>
+	and <m>\coords{\xvec}{\ccal}=\twovec{-37/5}{-3/5}</m>.
+	</p></li>
+
+	<li><p>
+	  <m>Q =
+	  \left[\begin{array}{rr}
+	  \frac95 \amp -1 \\
+	  \frac15 \amp 0 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> In both cases, we see that
@@ -230,38 +260,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> The sets of the vectors are both
-	linearly independent and span <m>\real^2</m>.
-	</p></li>
 
-	<li><p> 
-	<m>\coords{\xvec}{\bcal}=\twovec{12/5}{13/5}</m> and
-	<m>\coords{\xvec}{\ccal}=\twovec{13}{21}</m>.
-	</p></li>
 
-	<li><p> <m>\xvec=
-	\twovec{-2}{16}</m> and
-	<m>\coords{\xvec}{\ccal}=\twovec{-20}{-38}</m>.
-	</p></li>
-
-	<li><p> <m>\xvec=\twovec{-8}{-13}</m>
-	and <m>\coords{\xvec}{\ccal}=\twovec{-37/5}{-3/5}</m>.
-	</p></li>
-
-	<li><p>
-	  <m>Q = 
-	  \left[\begin{array}{rr}
-	  \frac95 \amp -1 \\
-	  \frac15 \amp 0 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
       
   <exercise>
@@ -296,6 +296,29 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  The vectors are linearly independent and span
+	  <m>\real^4</m>.
+	</p></li>
+
+	<li><p> We have <m>\xvec = P_{\bcal}\coords{\xvec}{\bcal}</m>.
+	</p></li>
+
+	<li><p> We have <m>\coords{\xvec}{\bcal} =
+	P_{\bcal}^{-1}\xvec</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\coords{\xvec}{\bcal}=\fourvec{23}{-11}{-2}{9}</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\xvec=\fourvec{3}{4}{1}{-3}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Form the matrix
@@ -346,31 +369,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  The vectors are linearly independent and span
-	  <m>\real^4</m>.
-	</p></li>
 
-	<li><p> We have <m>\xvec = P_{\bcal}\coords{\xvec}{\bcal}</m>.
-	</p></li>
 
-	<li><p> We have <m>\coords{\xvec}{\bcal} =
-	P_{\bcal}^{-1}\xvec</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\coords{\xvec}{\bcal}=\fourvec{23}{-11}{-2}{9}</m>.
-	</p></li>
-
-	<li><p>
-	  <m>\xvec=\fourvec{3}{4}{1}{-3}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -414,6 +414,22 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> No, because a basis for <m>\real^3</m> must contain
+	exactly three vectors.
+	</p></li>
+
+	<li><p>
+	  <m>\vvec_1</m>,
+	  <m>\vvec_2</m>, and <m>\vvec_4</m>.
+	</p></li>
+
+	<li><p> <m>\vvec_1</m>,
+	<m>\vvec_2</m>, <m>\vvec_4</m>, and <m>\vvec_6</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Looking at the reduced row echelon form, we find
@@ -455,22 +471,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> No, because a basis for <m>\real^3</m> must contain
-	exactly three vectors.
-	</p></li>
-
-	<li><p>
-	  <m>\vvec_1</m>,
-	  <m>\vvec_2</m>, and <m>\vvec_4</m>.
-	</p></li>
-
-	<li><p> <m>\vvec_1</m>,
-	<m>\vvec_2</m>, <m>\vvec_4</m>, and <m>\vvec_6</m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -515,6 +515,25 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  The vectors
+	  are linearly independent and span <m>\real^3</m>.
+	</p></li>
+
+	<li><p> <m>\coords{\xvec}{\bcal} = \threevec{15}{0}{0}</m>.
+	</p></li>
+
+	<li><p>
+	  Since we have
+	  <m>\coords{\xvec}{\bcal}=C_{\bcal}^{-1}\xvec</m>, we have
+	  <m>c_1=\frac13 x_1 + \frac13 x_2 + \frac13 x_3 =
+	  \frac13(x_1+x_2+x_3)
+	  </m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> By forming the matrix
@@ -553,27 +572,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  The vectors
-	  are linearly independent and span <m>\real^3</m>.  
-	</p></li>
 
-	<li><p> <m>\coords{\xvec}{\bcal} = \threevec{15}{0}{0}</m>.
-	</p></li>
 
-	<li><p>
-	  Since we have
-	  <m>\coords{\xvec}{\bcal}=C_{\bcal}^{-1}\xvec</m>, we have
-	  <m>c_1=\frac13 x_1 + \frac13 x_2 + \frac13 x_3 =
-	  \frac13(x_1+x_2+x_3)
-	  </m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 	
   <exercise>
@@ -604,6 +604,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -639,16 +648,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-      </ol></p>
-    </answer>
-	  
+
   </exercise>
 
   <exercise>
@@ -679,6 +679,14 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Yes </p></li>
+	<li><p> Yes </p></li>
+	<li><p> Yes </p></li>
+	<li><p> Yes </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -714,14 +722,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Yes </p></li>
-	<li><p> Yes </p></li>
-	<li><p> Yes </p></li>
-	<li><p> Yes </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -804,6 +804,36 @@
 	</ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  The points are indicated in the figure.
+          </p>
+	  <image width="50%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-graphite-sol-ans">
+              <xi:include href="prefigure/ex-graphite-sol.xml"/>
+            </prefigure>
+          </image>
+	</li>
+
+	<li><p> <m>\coords{\xvec}{\bcal} =
+	\twovec{0}{0}, \twovec{1}{0}, \twovec{2}{1}, \twovec{2}{2},
+	\twovec{1}{2}, \twovec{0}{1}
+	</m>.
+	</p></li>
+
+	<li><p> <m>\coords{\xvec}{\bcal} = \twovec{1}{1}</m>.
+	</p></li>
+
+	<li><p> The coordinates differ by
+	<m>\twovec{4}{2}</m>
+	</p></li>
+
+	<li><p> It is the center of a hexagon.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li>
@@ -851,37 +881,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  The points are indicated in the figure.
-          </p>
-	  <image width="50%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-graphite-sol-ans">
-              <xi:include href="prefigure/ex-graphite-sol.xml"/>
-            </prefigure>
-          </image>
-	</li>
 
-	<li><p> <m>\coords{\xvec}{\bcal} = 
-	\twovec{0}{0}, \twovec{1}{0}, \twovec{2}{1}, \twovec{2}{2},
-	\twovec{1}{2}, \twovec{0}{1}
-	</m>.
-	</p></li>
-
-	<li><p> <m>\coords{\xvec}{\bcal} = \twovec{1}{1}</m>.
-	</p></li>
-
-	<li><p> The coordinates differ by 
-	<m>\twovec{4}{2}</m>
-	</p></li>
-
-	<li><p> It is the center of a hexagon. 
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -917,6 +917,34 @@
       </p>
     </statement>
       
+  <answer>
+    <p><ol marker="a.">
+      <li><p> The vectors are linearly independent and span
+      <m>\real^2</m>.
+      </p></li>
+
+      <li><p> <m>A\vvec_1 = 3\vvec_1</m> and
+      <m>A\vvec_2=\vvec_2</m>.
+      </p></li>
+
+      <li><p> <m>\coords{A\vvec_1}{\bcal} = \twovec{3}{0}</m> and
+      <m>\coords{A\vvec_2}{\bcal} = \twovec{0}{1}</m>.
+      </p></li>
+
+      <li><p>
+      <m>\coords{A\xvec}{\bcal}=\twovec{3}{-5}</m>.
+      </p></li>
+
+      <li><p>
+      <m>D=
+      \left[\begin{array}{rr}
+      3 \amp 0 \\
+      0 \amp 1 \\
+      \end{array}\right]
+      </m>.
+      </p></li>
+    </ol></p>
+  </answer>
   <solution>
     <p><ol marker="a.">
       <li><p> The vectors are linearly independent and span
@@ -949,35 +977,7 @@
       </p></li>
     </ol></p>
   </solution>
-      
-  <answer>
-    <p><ol marker="a.">
-      <li><p> The vectors are linearly independent and span
-      <m>\real^2</m>.
-      </p></li>
 
-      <li><p> <m>A\vvec_1 = 3\vvec_1</m> and
-      <m>A\vvec_2=\vvec_2</m>.
-      </p></li>
-
-      <li><p> <m>\coords{A\vvec_1}{\bcal} = \twovec{3}{0}</m> and 
-      <m>\coords{A\vvec_2}{\bcal} = \twovec{0}{1}</m>.
-      </p></li>
-
-      <li><p> 
-      <m>\coords{A\xvec}{\bcal}=\twovec{3}{-5}</m>.
-      </p></li>
-
-      <li><p> 
-      <m>D=
-      \left[\begin{array}{rr}
-      3 \amp 0 \\
-      0 \amp 1 \\
-      \end{array}\right]
-      </m>.
-      </p></li>
-    </ol></p>
-  </answer>
   </exercise>
       
 </exercises>

--- a/src/exercises/exercises3-3.xml
+++ b/src/exercises/exercises3-3.xml
@@ -45,6 +45,45 @@ print (Pinv.numerical_approx(digits=3))
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	  \left[\begin{array}{c}
+	  100\\ -5.99 \\ 3.98 \\ 4.46 \\ 1.94 \\ -0.97 \\ 0.84 \\
+	  1.07 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p> <m>
+	  \yvec=\left[\begin{array}{c}
+	  103 \\ 94 \\ 91 \\ 92 \\ 103 \\ 105 \\ 105 \\ 108
+	  \end{array}\right]
+	</m>
+	</p></li>
+
+	<li><p>
+	  <m>
+	  \yvec=\left[\begin{array}{c}
+	  94 \\ 95 \\ 97 \\ 99 \\ 101 \\ 103 \\ 105 \\ 106
+	  \end{array}\right]
+	  </m>
+	</p></li>
+
+	<li><p> In the first approximation, the reconstructed vector
+	<m>\yvec</m> agrees with the original vector <m>\xvec</m>.  In
+	the second approximation, there are only two nonzero Fourier
+	coefficients, and we see that the approximating vector differs
+	from the original vector.  In the second case, however, we are
+	using only one quarter of the Fourier coefficients.  Though
+	the entries in the vector <m>\yvec</m> differ from those in the
+	original vector <m>\xvec</m>, the difference is probably not
+	visually noticeable since the possible values range from 0 to
+	255.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>
@@ -107,46 +146,7 @@ print (Pinv.numerical_approx(digits=3))
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m> 
-	  \left[\begin{array}{c}
-	  100\\ -5.99 \\ 3.98 \\ 4.46 \\ 1.94 \\ -0.97 \\ 0.84 \\
-	  1.07 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
 
-	<li><p> <m>
-	  \yvec=\left[\begin{array}{c}
-	  103 \\ 94 \\ 91 \\ 92 \\ 103 \\ 105 \\ 105 \\ 108
-	  \end{array}\right]
-	</m>
-	</p></li>
-
-	<li><p>
-	  <m>
-	  \yvec=\left[\begin{array}{c}
-	  94 \\ 95 \\ 97 \\ 99 \\ 101 \\ 103 \\ 105 \\ 106
-	  \end{array}\right]
-	  </m>
-	</p></li>
-
-	<li><p> In the first approximation, the reconstructed vector
-	<m>\yvec</m> agrees with the original vector <m>\xvec</m>.  In
-	the second approximation, there are only two nonzero Fourier
-	coefficients, and we see that the approximating vector differs
-	from the original vector.  In the second case, however, we are
-	using only one quarter of the Fourier coefficients.  Though
-	the entries in the vector <m>\yvec</m> differ from those in the
-	original vector <m>\xvec</m>, the difference is probably not
-	visually noticeable since the possible values range from 0 to
-	255.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -176,6 +176,43 @@ print (Pinv.numerical_approx(digits=3))
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> The goal is to represent the image in a format that
+	requires less storage but still allows us to reconstruct the
+	image with most of the visual information preserved.
+	</p></li>
+
+	<li><p> In the <m>YC_bC_r</m> color model, the most significant
+	visual information is stored in the <m>Y</m> channel.
+	Therefore, we should store most of this information.  The
+	information in the <m>C_b</m> and <m>C_r</m> channels is not
+	as visually significant so we can store a smaller amount of
+	that data without noticing the effect.
+	</p></li>
+
+	<li><p> As seen in an image, these blocks are relatively
+	small, which means that the approximations we reconstruct are
+	probably not noticeably different from the original.  Also,
+	the blocks are small enough so that the image does not
+	typically change a lot over the block.  At the same time, the
+	blocks are large enough to allow us to save storage by
+	throwing away some of the Fourier coefficients.
+	</p></li>
+
+	<li><p> The Discrete Fourier Transform represents the data in
+	a block as its average and variations from the average.
+	Since the blocks are relatively small, there will typically be
+	small variations away from the average.  Therefore, we can
+	often ignore those variations without visually
+	detecting the approximation.  </p></li>
+
+	<li><p> Our eyes do not detect individual pixels so we do not
+	detect differences from one pixel to the next.  This means that
+	we do not typically notice rapid variations.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The goal is to represent the image in a format that
@@ -213,45 +250,8 @@ print (Pinv.numerical_approx(digits=3))
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p> The goal is to represent the image in a format that
-	requires less storage but still allows us to reconstruct the
-	image with most of the visual information preserved.
-	</p></li>
 
-	<li><p> In the <m>YC_bC_r</m> color model, the most significant
-	visual information is stored in the <m>Y</m> channel.
-	Therefore, we should store most of this information.  The
-	information in the <m>C_b</m> and <m>C_r</m> channels is not
-	as visually significant so we can store a smaller amount of
-	that data without noticing the effect.
-	</p></li>
 
-	<li><p> As seen in an image, these blocks are relatively
-	small, which means that the approximations we reconstruct are
-	probably not noticeably different from the original.  Also,
-	the blocks are small enough so that the image does not
-	typically change a lot over the block.  At the same time, the
-	blocks are large enough to allow us to save storage by
-	throwing away some of the Fourier coefficients.
-	</p></li>
-
-	<li><p> The Discrete Fourier Transform represents the data in
-	a block as its average and variations from the average.
-	Since the blocks are relatively small, there will typically be
-	small variations away from the average.  Therefore, we can
-	often ignore those variations without visually
-	detecting the approximation.  </p></li>
-
-	<li><p> Our eyes do not detect individual pixels so we do not
-	detect differences from one pixel to the next.  This means that
-	we do not typically notice rapid variations.
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -407,6 +407,51 @@ C = matrix(cosmat).numerical_approx()
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	<m>
+	  \coords{\xvec}{\scal} =
+	  \left[\begin{array}{c}
+	  220 \\ 18.7 \\ 79.3 \\ 5.3 \\
+	  \end{array}\right]
+	  </m> and
+	  <m>
+	  \coords{\xvec}{\ccal} =
+	  \left[\begin{array}{c}
+	  165 \\ 20.1 \\ -11.0 \\ -0.3 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p> The higher Fourier Cosine coefficients are smaller
+	than their counterparts in the Fourier Sine transform.  This
+	means that we can ignore these coefficients in the Fourier
+	Cosine transform without losing too much information.
+	</p></li>
+
+	<li><p>
+	<m>
+	  \coords{\xvec}{\scal} =
+	  \left[\begin{array}{c}
+	  131 \\ 0 \\ 54.1 \\ 0 \\
+	  \end{array}\right]
+	  </m> and
+	  <m>
+	  \coords{\xvec}{\ccal} =
+	  \left[\begin{array}{c}
+	  100 \\ 0 \\ 0 \\ 0
+	  \end{array}\right]
+	</m>.
+	</p></li>
+
+	<li><p> Generally speaking, we can safely ignore more of the
+	coefficients in the Fourier Cosine transform.  Most of the
+	important information is channeled into the first coefficient,
+	which records the average of the components of the vector
+	<m>\xvec</m>.  </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We find that
@@ -449,51 +494,6 @@ C = matrix(cosmat).numerical_approx()
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> 
-	<m>
-	  \coords{\xvec}{\scal} =
-	  \left[\begin{array}{c}
-	  220 \\ 18.7 \\ 79.3 \\ 5.3 \\
-	  \end{array}\right]
-	  </m> and
-	  <m>
-	  \coords{\xvec}{\ccal} =
-	  \left[\begin{array}{c}
-	  165 \\ 20.1 \\ -11.0 \\ -0.3 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p> The higher Fourier Cosine coefficients are smaller
-	than their counterparts in the Fourier Sine transform.  This
-	means that we can ignore these coefficients in the Fourier
-	Cosine transform without losing too much information.
-	</p></li>
-
-	<li><p> 
-	<m>
-	  \coords{\xvec}{\scal} =
-	  \left[\begin{array}{c}
-	  131 \\ 0 \\ 54.1 \\ 0 \\
-	  \end{array}\right]
-	  </m> and
-	  <m>
-	  \coords{\xvec}{\ccal} =
-	  \left[\begin{array}{c}
-	  100 \\ 0 \\ 0 \\ 0
-	  \end{array}\right]
-	</m>.
-	</p></li>
-
-	<li><p> Generally speaking, we can safely ignore more of the
-	coefficients in the Fourier Cosine transform.  Most of the
-	important information is channeled into the first coefficient,
-	which records the average of the components of the vector
-	<m>\xvec</m>.  </p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -681,6 +681,54 @@ print (approx_luminance.numerical_approx(digits=3))
       algorithm.  </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\coords{\xvec}{\wcal} =
+	\left[\begin{array}{c}
+	165 \\ 13.2 \\ -2.5 \\ 13.0 \\
+	\end{array}\right]
+	</m>.
+	</p></li>
+
+	<li><p>
+	  <m>\yvec=\left[\begin{array}{c}
+	  178.2 \\ 178.2 \\ 151.8 \\ 151.8 \\
+	  \end{array}\right]
+	  </m>.
+	</p></li>
+
+	<li><p> The first two components are equal as are the last two
+	components.
+	</p></li>
+
+	<li><p> We find the wavelet coefficients
+	<md>
+	  \left[\begin{array}{rrrr}
+	  167 \amp -0.7 \amp -1.0 \amp 1.9 \\
+	  6.4 \amp 3.8 \amp 3.0 \amp 0.4 \\
+	  -2.1 \amp -1.4 \amp 1.0 \amp -1.8 \\
+	  5.8 \amp 5.8 \amp 1.5 \amp 2.5 \\
+	  \end{array}\right]\text{.}
+	</md>
+	</p></li>
+
+	<li><p> We find the approximate luminance values to be
+	<md>
+	  \left[\begin{array}{rrrr}
+	  177 \amp 177 \amp 170 \amp 170 \\
+	  177 \amp 177 \amp 170 \amp 170 \\
+	  156 \amp 156 \amp 165 \amp 165 \\
+	  156 \amp 156 \amp 165 \amp 165 \\
+	  \end{array}\right]\text{.}
+	</md>
+	</p></li>
+
+	<li><p> The luminance values are constant on <m>2\times2</m>
+	blocks.  It is as if the image is represented with pixels that
+	are twice as wide and twice as tall.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We find that <m>\coords{\xvec}{\wcal} =
@@ -733,55 +781,7 @@ print (approx_luminance.numerical_approx(digits=3))
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\coords{\xvec}{\wcal} =
-	\left[\begin{array}{c}
-	165 \\ 13.2 \\ -2.5 \\ 13.0 \\
-	\end{array}\right]
-	</m>.
-	</p></li>
 
-	<li><p> 
-	  <m>\yvec=\left[\begin{array}{c}
-	  178.2 \\ 178.2 \\ 151.8 \\ 151.8 \\
-	  \end{array}\right]
-	  </m>.
-	</p></li>
-
-	<li><p> The first two components are equal as are the last two
-	components.  
-	</p></li>
-
-	<li><p> We find the wavelet coefficients
-	<md>
-	  \left[\begin{array}{rrrr}
-	  167 \amp -0.7 \amp -1.0 \amp 1.9 \\
-	  6.4 \amp 3.8 \amp 3.0 \amp 0.4 \\
-	  -2.1 \amp -1.4 \amp 1.0 \amp -1.8 \\
-	  5.8 \amp 5.8 \amp 1.5 \amp 2.5 \\
-	  \end{array}\right]\text{.}
-	</md>
-	</p></li>
-
-	<li><p> We find the approximate luminance values to be
-	<md>
-	  \left[\begin{array}{rrrr}
-	  177 \amp 177 \amp 170 \amp 170 \\
-	  177 \amp 177 \amp 170 \amp 170 \\
-	  156 \amp 156 \amp 165 \amp 165 \\
-	  156 \amp 156 \amp 165 \amp 165 \\
-	  \end{array}\right]\text{.}
-	</md>
-	</p></li>
-
-	<li><p> The luminance values are constant on <m>2\times2</m>
-	blocks.  It is as if the image is represented with pixels that
-	are twice as wide and twice as tall.
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -892,22 +892,6 @@ print (approx_luminance.numerical_approx(digits=3))
 
     </statement>
 
-    <solution>
-      <p><ol marker="a.">
-	<li><p> The color changes but not the brightness. </p></li>
-	<li><p> The color appears more <q>washed out</q> with a low
-	saturation and appears more vibrant with a high
-	saturation. </p></li>
-	<li><p> The brightness changes. </p></li>
-	<li><p> Set the saturation <m>S=0</m> and the value
-	<m>V=255</m>. </p></li>
-
-	<li><p> Set <m>S=V=0</m>. </p></li>
-	<li><p> <m>128\leq H \leq 192</m>. </p></li>
-	<li><p> <m>64\leq H \leq 128</m>. </p></li>
-      </ol></p>
-    </solution>
-	
     <answer>
       <p><ol marker="a.">
 	<li><p> The color changes but not the brightness. </p></li>
@@ -923,7 +907,23 @@ print (approx_luminance.numerical_approx(digits=3))
 	<li><p> <m>64\leq H \leq 128</m>. </p></li>
       </ol></p>
     </answer>
-	
+    <solution>
+      <p><ol marker="a.">
+	<li><p> The color changes but not the brightness. </p></li>
+	<li><p> The color appears more <q>washed out</q> with a low
+	saturation and appears more vibrant with a high
+	saturation. </p></li>
+	<li><p> The brightness changes. </p></li>
+	<li><p> Set the saturation <m>S=0</m> and the value
+	<m>V=255</m>. </p></li>
+
+	<li><p> Set <m>S=V=0</m>. </p></li>
+	<li><p> <m>128\leq H \leq 192</m>. </p></li>
+	<li><p> <m>64\leq H \leq 128</m>. </p></li>
+      </ol></p>
+    </solution>
+
+
   </exercise>
   
 </exercises>

--- a/src/exercises/exercises3-4.xml
+++ b/src/exercises/exercises3-4.xml
@@ -30,14 +30,14 @@
       </ol></p>
     </statement>
 
-    <solution>
-      <p> We find that <m>\det(A) = 12</m> and <m>\det(B) = -24</m>.
-      </p>
-    </solution>
     <answer>
       <p> <m>\det(A) = 12</m> and <m>\det(B) = -24</m>.
       </p>
     </answer>
+    <solution>
+      <p> We find that <m>\det(A) = 12</m> and <m>\det(B) = -24</m>.
+      </p>
+    </solution>
   </exercise>
 
   <exercise>
@@ -77,6 +77,12 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\det(A) = 1</m>. </p></li>
+	<li><p> <m>\det(B) = -1</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The vectors <m>\vvec_1</m> and <m>\vvec_2</m> that
@@ -102,13 +108,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\det(A) = 1</m>. </p></li>
-	<li><p> <m>\det(B) = -1</m>. </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -140,6 +140,13 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\det(A) = \det(B)</m> because <m>\det(P) \det(P^{-1}) =
+	1</m>. </p></li>
+	<li><p> <m>\det(A) = 30</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> <m>\det(A) = \det(P) \det(B) \det(P^{-1}) =
@@ -151,13 +158,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\det(A) = \det(B)</m> because <m>\det(P) \det(P^{-1}) =
-	1</m>. </p></li>
-	<li><p> <m>\det(A) = 30</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -186,6 +186,12 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\det(A) = k-16</m> </p></li>
+	<li><p> <m>k\neq 16</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We see that <m>\det(A) = k-16</m>. </p></li>
@@ -197,12 +203,6 @@
 	</ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\det(A) = k-16</m> </p></li>
-	<li><p> <m>k\neq 16</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -231,6 +231,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> False.  This is a row replacement operation, which
@@ -256,15 +265,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -286,6 +286,19 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\det(2A) = -64</m>. </p></li>
+
+	<li><p> <m>\det(A^3) = -8</m>. </p></li>
+
+	<li><p> <m>\det(AB) = -10</m>. </p></li>
+
+	<li><p> <m>\det(-A) = 2</m>. </p></li>
+
+	<li><p> <m>\det (AB^{-1}) = -\frac 25</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Multiplying the entire matrix by <m>2</m> scales each
@@ -306,19 +319,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\det(2A) = -64</m>. </p></li>
-
-	<li><p> <m>\det(A^3) = -8</m>. </p></li>
-
-	<li><p> <m>\det(AB) = -10</m>. </p></li>
-
-	<li><p> <m>\det(-A) = 2</m>. </p></li>
-
-	<li><p> <m>\det (AB^{-1}) = -\frac 25</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -335,6 +335,19 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> If <m>A</m> and <m>B</m> are invertible, then
+	<m>\det(A) \neq 0</m> and <m>\det(B) \neq 0</m>.  Therefore,
+	<m>\det(AB) = \det(A)\det(B) \neq 0</m>, which shows that <m>AB</m> is
+	invertible. </p></li>
+
+	<li><p> If <m>AB</m> is invertible, then <m>\det (AB) = \det(A)
+	\det(B) \neq 0</m>.  This implies that <m>\det(A)\neq0</m> and
+	<m>\det(B) \neq 0</m>, from which we conclude that both
+	<m>A</m> and <m>B</m> are invertible. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If <m>A</m> and <m>B</m> are invertible, then
@@ -349,19 +362,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> If <m>A</m> and <m>B</m> are invertible, then
-	<m>\det(A) \neq 0</m> and <m>\det(B) \neq 0</m>.  Therefore,
-	<m>\det(AB) = \det(A)\det(B) \neq 0</m>, which shows that <m>AB</m> is
-	invertible. </p></li>
-
-	<li><p> If <m>AB</m> is invertible, then <m>\det (AB) = \det(A)
-	\det(B) \neq 0</m>.  This implies that <m>\det(A)\neq0</m> and
-	<m>\det(B) \neq 0</m>, from which we conclude that both
-	<m>A</m> and <m>B</m> are invertible. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
 
@@ -385,6 +385,10 @@
       </p>
     </statement>
 
+    <answer>
+      <p> In all four cases, the determinant must be zero.
+      </p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The determinant must be zero.  This is because the
@@ -411,11 +415,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p> In all four cases, the determinant must be zero. 
-      </p>
-    </answer>
-    
+
   </exercise>
 
   <exercise>
@@ -443,6 +443,21 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\det(A) =
+	2x-y-2z = 0</m>. </p></li>
+
+	<li><p> If we replace the third column by either
+	<m>\vvec_1</m> or <m>\vvec_2</m>, we obtain a matrix whose
+	columns are linearly dependent.
+	</p></li>
+
+	<li><p> If <m>\det(A)=0</m> for a vector <m>\threevec xyz</m>,
+	then <m>\threevec xyz</m> is a linear combination of
+	<m>\vvec_1</m> and <m>\vvec_2</m>.</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Using a cofactor expansion, we have <m>\det(A) =
@@ -461,21 +476,6 @@
 	the plane that is their span.</p></li>
       </ol></p>
     </solution>
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\det(A) =
-	2x-y-2z = 0</m>. </p></li>
-
-	<li><p> If we replace the third column by either
-	<m>\vvec_1</m> or <m>\vvec_2</m>, we obtain a matrix whose
-	columns are linearly dependent. 
-	</p></li>
-
-	<li><p> If <m>\det(A)=0</m> for a vector <m>\threevec xyz</m>,
-	then <m>\threevec xyz</m> is a linear combination of
-	<m>\vvec_1</m> and <m>\vvec_2</m>.</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -537,6 +537,18 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Column replacements do not change the determinant
+	because <m>\det(R)=1</m>. </p></li>
+	<li><p> Scaling a column by <m>r</m> multiplies the
+	determinant by <m>r</m>
+	because <m>\det(S)=r</m>. </p></li>
+	<li><p> Interchanges change the sign of the determinant
+	because <m>\det(P)=-1</m>. </p></li>
+	<li><p> <m>\det(A) = -12</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The columns of <m>AR</m> are found by multiplying the
@@ -598,18 +610,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Column replacements do not change the determinant
-	because <m>\det(R)=1</m>. </p></li>
-	<li><p> Scaling a column by <m>r</m> multiplies the
-	determinant by <m>r</m> 
-	because <m>\det(S)=r</m>. </p></li>
-	<li><p> Interchanges change the sign of the determinant
-	because <m>\det(P)=-1</m>. </p></li>
-	<li><p> <m>\det(A) = -12</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -639,6 +639,10 @@
       </p>
     </statement>
 
+    <answer>
+      <p> <m>\det(A) = -1</m>, <m>\det(B) = 1</m>, and <m>\det(C) =
+      abcd</m>. </p>
+    </answer>
     <solution>
       <p> It takes three interchanges to see that <m>A\sim
       I</m>, which implies that <m>\det(A) = -1</m>. </p>
@@ -650,10 +654,6 @@
       <m>\det(C) = abcd</m>. </p>
     </solution>
 
-    <answer>
-      <p> <m>\det(A) = -1</m>, <m>\det(B) = 1</m>, and <m>\det(C) =
-      abcd</m>. </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -701,6 +701,16 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\det(A) = -1</m>, <m>\det(B) = 0</m>, <m>\det(C) =
+	1</m>, and <m>\det(D) = 0</m>. </p></li>
+
+	<li><p> If <m>E</m> and <m>F</m> are the <m>6\times6</m> and
+	<m>7\times7</m> matrices, respectively, we expect that
+	<m>\det(E) = -1</m> and <m>\det(F) = 0</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> <m>\det(A) = -1</m>, <m>\det(B) = 0</m>, <m>\det(C) =
@@ -712,17 +722,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\det(A) = -1</m>, <m>\det(B) = 0</m>, <m>\det(C) =
-	1</m>, and <m>\det(D) = 0</m>. </p></li>
 
-	<li><p> If <m>E</m> and <m>F</m> are the <m>6\times6</m> and
-	<m>7\times7</m> matrices, respectively, we expect that
-	<m>\det(E) = -1</m> and <m>\det(F) = 0</m>. </p></li> 
-      </ol></p>
-    </answer>
-    
   </exercise>
       
   <exercise>
@@ -756,6 +756,19 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Perform a sequence of row operations to form an upper
+	triangular matrix. </p></li>
+
+	<li><p> If <m>a</m>, <m>b</m>, and <m>c</m> are distinct, then
+	<m>\det(V) \neq 0</m>.
+	</p></li>
+
+	<li><p> The determinant is
+	<m>(d-a)(d-b)(d-c)(c-a)(c-b)(b-a)</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If <m>a</m>, <m>b</m>, and <m>c</m> are not distinct,
@@ -812,20 +825,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Perform a sequence of row operations to form an upper
-	triangular matrix. </p></li>
 
-	<li><p> If <m>a</m>, <m>b</m>, and <m>c</m> are distinct, then
-	<m>\det(V) \neq 0</m>.
-	</p></li>
-
-	<li><p> The determinant is
-	<m>(d-a)(d-b)(d-c)(c-a)(c-b)(b-a)</m>. </p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises3-5.xml
+++ b/src/exercises/exercises3-5.xml
@@ -40,6 +40,35 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\nul(A)</m> is a subspace of <m>\real^6</m> and
+	<m>\col(A)</m> is a subspace of <m>\real^4</m>. </p></li>
+
+	<li><p> <m>\dim~\nul(A) = 3</m>
+	and <m>\dim~\col(A)=3</m>. </p></li>
+
+	<li><p> <m>
+	  \fourvec{2}{-4}{6}{4},
+	  \fourvec{0}{-1}{0}{-1},
+	  \fourvec{0}{0}{3}{0}
+	</m>
+	</p></li>
+
+	<li><p> <m>
+	  \left[\begin{array}{r}
+	  1 \\ 0 \\ 0 \\ 0 \\ 0 \\ 0 \\
+	  \end{array}\right],
+	  \left[\begin{array}{r}
+	  0 \\ 2 \\ -1 \\ 1 \\ 0 \\ 0 \\
+	  \end{array}\right],
+	  \left[\begin{array}{r}
+	  0 \\ -3 \\ -4 \\ 0 \\ 1 \\ 1
+	  \end{array}\right]
+	</m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> <m>\nul(A)</m> is a subspace of <m>\real^6</m> and
@@ -93,37 +122,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\nul(A)</m> is a subspace of <m>\real^6</m> and
-	<m>\col(A)</m> is a subspace of <m>\real^4</m>. </p></li>
 
-	<li><p> <m>\dim~\nul(A) = 3</m>
-	and <m>\dim~\col(A)=3</m>. </p></li>
 
-	<li><p> <m>
-	  \fourvec{2}{-4}{6}{4},
-	  \fourvec{0}{-1}{0}{-1},
-	  \fourvec{0}{0}{3}{0}
-	</m>
-	</p></li>
-
-	<li><p> <m>
-	  \left[\begin{array}{r}
-	  1 \\ 0 \\ 0 \\ 0 \\ 0 \\ 0 \\
-	  \end{array}\right],
-	  \left[\begin{array}{r}
-	  0 \\ 2 \\ -1 \\ 1 \\ 0 \\ 0 \\
-	  \end{array}\right],
-	  \left[\begin{array}{r}
-	  0 \\ -3 \\ -4 \\ 0 \\ 1 \\ 1
-	  \end{array}\right]
-	</m>
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -155,6 +155,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Yes </p></li>
+	<li><p> No </p></li>
+	<li><p> No </p></li>
+	<li><p> Yes </p></li>
+	<li><p> No </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Yes.  This vector is a column of <m>A</m> so it may be
@@ -175,16 +184,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Yes </p></li>
-	<li><p> No </p></li>
-	<li><p> No </p></li>
-	<li><p> Yes </p></li>
-	<li><p> No </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -213,6 +213,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> False.  <m>\nul(A)</m> is a subspace of
@@ -238,15 +247,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -266,6 +266,22 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> If <m>BA\xvec=\zerovec</m>, then
+	<m>A\xvec=\zerovec</m> if <m>B</m> is invertible. </p></li>
+
+	<li><p> The column space consists of all the vectors
+	<m>\bvec</m> for which <m>A\xvec=\bvec</m> is consistent.  We
+	can rewrite this condition as <m>AB(B^{-1}\xvec)=\bvec</m>,
+	which means that <m>A\xvec=\bvec</m> is consistent exactly
+	when <m>AB\xvec=\bvec</m> is. </p></li>
+
+	<li><p> If <m>A\sim A'</m>, then <m>A</m> and <m>A'</m>
+	have the same reduced row echelon form, which determines
+	<m>\nul(A)</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If <m>BA\xvec=\zerovec</m>, then
@@ -283,22 +299,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> If <m>BA\xvec=\zerovec</m>, then
-	<m>A\xvec=\zerovec</m> if <m>B</m> is invertible. </p></li>
-
-	<li><p> The column space consists of all the vectors
-	<m>\bvec</m> for which <m>A\xvec=\bvec</m> is consistent.  We
-	can rewrite this condition as <m>AB(B^{-1}\xvec)=\bvec</m>,
-	which means that <m>A\xvec=\bvec</m> is consistent exactly
-	when <m>AB\xvec=\bvec</m> is. </p></li>
-
-	<li><p> If <m>A\sim A'</m>, then <m>A</m> and <m>A'</m>
-	have the same reduced row echelon form, which determines
-	<m>\nul(A)</m>. </p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -314,47 +314,6 @@
       </ol></p>
     </statement>
 
-    <solution>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    1 \amp 0 \amp 0 \\
-	    0 \amp 1 \amp 0 \\
-	    0 \amp 0 \amp 1 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    1 \amp 0 \amp -1 \\
-	    0 \amp 1 \amp 2 \\
-	    0 \amp 0 \amp 0 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    1 \amp 4 \amp -1 \\
-	    0 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 0 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-	<li><p>
-	  <m>
-	    \left[\begin{array}{rrr}
-	    0 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 0 \\
-	    0 \amp 0 \amp 0 \\
-	    \end{array}\right]
-	    </m>.
-	</p></li>
-      </ol></p>
-    </solution>
-	
     <answer>
       <p><ol marker="a.">
 	<li><p>
@@ -395,7 +354,48 @@
 	</p></li>
       </ol></p>
     </answer>
-	
+    <solution>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    1 \amp 0 \amp 0 \\
+	    0 \amp 1 \amp 0 \\
+	    0 \amp 0 \amp 1 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    1 \amp 0 \amp -1 \\
+	    0 \amp 1 \amp 2 \\
+	    0 \amp 0 \amp 0 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    1 \amp 4 \amp -1 \\
+	    0 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 0 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+	<li><p>
+	  <m>
+	    \left[\begin{array}{rrr}
+	    0 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 0 \\
+	    0 \amp 0 \amp 0 \\
+	    \end{array}\right]
+	    </m>.
+	</p></li>
+      </ol></p>
+    </solution>
+
+
   </exercise>
 
   <exercise>
@@ -419,6 +419,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> No </p></li>
+	<li><p> <m>\col(A) = \real^3</m> </p></li>
+	<li><p> <m>\col(A)</m> is a plane in <m> \real^3</m> </p></li>
+	<li><p> <m>\col(A)</m> is a line in <m>\real^3</m> </p></li>
+	<li><p> <m>\col(A)=\{\zerovec\}</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> No.  There are more columns than rows so there must be
@@ -439,15 +448,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> No </p></li>
-	<li><p> <m>\col(A) = \real^3</m> </p></li>
-	<li><p> <m>\col(A)</m> is a plane in <m> \real^3</m> </p></li>
-	<li><p> <m>\col(A)</m> is a line in <m>\real^3</m> </p></li>
-	<li><p> <m>\col(A)=\{\zerovec\}</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -472,6 +472,20 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>3\times4</m></p></li>
+	<li><p>
+	  <m>
+	    A = \left[\begin{array}{rrrr}
+	    2 \amp -1 \amp -7 \amp 8 \\
+	    3 \amp 2 \amp -7 \amp -2 \\
+	    -1 \amp 4 \amp 7 \amp -18 \\
+	    \end{array}\right]
+	  </m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Since <m>\vvec_1</m> and <m>\vvec_2</m> are
@@ -504,20 +518,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>3\times4</m></p></li>
-	<li><p>
-	  <m>
-	    A = \left[\begin{array}{rrrr}
-	    2 \amp -1 \amp -7 \amp 8 \\
-	    3 \amp 2 \amp -7 \amp -2 \\
-	    -1 \amp 4 \amp 7 \amp -18 \\
-	    \end{array}\right]
-	  </m>
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -535,15 +535,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p> <m>\nul(A)=\{\zerovec\}</m> and <m>\col(A) = \real^8</m>.
+      </p>
+    </answer>
     <solution>
       <p> We know that <m>A</m> is invertible so
       <m>\nul(A)=\{\zerovec\}</m> and <m>\col(A) = \real^8</m>.
       </p>
     </solution>
-    <answer>
-      <p> <m>\nul(A)=\{\zerovec\}</m> and <m>\col(A) = \real^8</m>.
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -568,15 +568,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p> <m>\nul(A)=\{\zerovec\}</m> and
+      <m>\col(A)=\real^3</m>. </p>
+    </answer>
     <solution>
       <p> We know that <m>\det A = -6</m> so <m>A</m> is invertible.
       Therefore, <m>\nul(A)=\{\zerovec\}</m> and
       <m>\col(A)=\real^3</m>. </p>
     </solution>
-    <answer>
-      <p> <m>\nul(A)=\{\zerovec\}</m> and
-      <m>\col(A)=\real^3</m>. </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -644,6 +644,34 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\xvec=x_2\twovec{2}{1}</m></p></li>
+
+	<li><p> The solution space forms a line through the
+	origin. </p></li>
+
+	<li><p> <m>\xvec=\twovec{2}{0}+x_2\twovec{2}{1}</m> </p></li>
+
+	<li><p> No </p></li>
+
+	<li><p> <m>\xvec=\twovec{-4}{0}+x_2\twovec{2}{1}</m>.
+	The graph of the solution spaces is shown below.</p>
+	<image width="50%">
+          <prefigure xmlns="https://prefigure.org"
+                     label="pf-ex-3-5-ans">
+            <xi:include href="prefigure/ex-3-5.xml"/>
+          </prefigure>
+        </image>
+	</li>
+
+	<li><p> They are all parallel to the solution space to the
+	homogeneous equation. </p></li>
+
+	<li><p> <m>\xvec=\zerovec</m> must be in the solution space.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have
@@ -693,36 +721,8 @@
 	\bvec</m>. </p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\xvec=x_2\twovec{2}{1}</m></p></li>
 
-	<li><p> The solution space forms a line through the
-	origin. </p></li>
 
-	<li><p> <m>\xvec=\twovec{2}{0}+x_2\twovec{2}{1}</m> </p></li>
-
-	<li><p> No </p></li>
-
-	<li><p> <m>\xvec=\twovec{-4}{0}+x_2\twovec{2}{1}</m>.
-	The graph of the solution spaces is shown below.</p>
-	<image width="50%">
-          <prefigure xmlns="https://prefigure.org"
-                     label="pf-ex-3-5-ans">
-            <xi:include href="prefigure/ex-3-5.xml"/>
-          </prefigure>
-        </image>
-	</li>
-
-	<li><p> They are all parallel to the solution space to the
-	homogeneous equation. </p></li>
-
-	<li><p> <m>\xvec=\zerovec</m> must be in the solution space.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises4-1.xml
+++ b/src/exercises/exercises4-1.xml
@@ -33,6 +33,26 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> We find that <m>A\vvec_1 = 3\vvec_1</m> and
+	<m>A\vvec_2=-2\vvec_2</m> so the associated eigenvalues are
+	<m>\lambda_1 = 3</m> and <m>\lambda_2=-2</m>. </p></li>
+
+	<li><p> <m>\xvec=\twovec{-4}{-1} = -3\vvec_1 +
+	2\vvec_2</m>. </p></li>
+
+	<li><p> We find
+	<md>
+	  \begin{alignedat}{3}
+	  A\xvec\amp{}={}\amp -9\vvec_1 \amp{}-{}\amp 4\vvec_2\\
+	  A^2\xvec\amp{}={}\amp -27\vvec_1\amp{}+{}\amp8\vvec_2 \\
+	  A^{-1}\xvec\amp{}={}\amp -\vvec_1 \amp{}-{}\amp \vvec_2\text{.} \\
+	  \end{alignedat}
+	</md>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We find that <m>A\vvec_1 = 3\vvec_1</m> and
@@ -55,26 +75,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> We find that <m>A\vvec_1 = 3\vvec_1</m> and
-	<m>A\vvec_2=-2\vvec_2</m> so the associated eigenvalues are
-	<m>\lambda_1 = 3</m> and <m>\lambda_2=-2</m>. </p></li>
-
-	<li><p> <m>\xvec=\twovec{-4}{-1} = -3\vvec_1 +
-	2\vvec_2</m>. </p></li>
-
-	<li><p> We find
-	<md>
-	  \begin{alignedat}{3}
-	  A\xvec\amp{}={}\amp -9\vvec_1 \amp{}-{}\amp 4\vvec_2\\
-	  A^2\xvec\amp{}={}\amp -27\vvec_1\amp{}+{}\amp8\vvec_2 \\
-	  A^{-1}\xvec\amp{}={}\amp -\vvec_1 \amp{}-{}\amp \vvec_2\text{.} \\
-	  \end{alignedat}
-	</md>
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 	
   <exercise>
@@ -110,6 +110,30 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> We see that <m>A\vvec_1=-3\vvec_1</m>, <m>A\vvec_2 =
+	-2\vvec_2</m>, and <m>A\vvec_3=4\vvec_3</m>.  The associated
+	eigenvalues are <m>\lambda_1 = -3</m>, <m>\lambda_2=-2</m>,
+	and <m>\lambda_3=4</m>. </p></li>
+
+	<li><p>
+	<m>\xvec=2\vvec_1 -\vvec_2+2\vvec_3</m>. </p></li>
+
+	<li><p> We find
+	<md>
+	  \begin{alignedat}{4}
+	  A\xvec\amp{}={}\amp -6\vvec_1 \amp{}+{}\amp
+	  2\vvec_2\amp{}+{} \amp 8\vvec_3\\
+	  A^2\xvec\amp{}={}\amp 18\vvec_1\amp{}-{}\amp
+	  4\vvec_2\amp{}+{}\amp 32\vvec_3\\
+	  A^{-1}\xvec\amp{}={}\amp -\frac23\vvec_1\amp
+	  {}+{}\amp\frac12\vvec_2\amp{}+{}\amp\frac12\vvec_3\text{.} \\
+	  \end{alignedat}
+	</md>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We see that <m>A\vvec_1=-3\vvec_1</m>, <m>A\vvec_2 =
@@ -135,30 +159,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> We see that <m>A\vvec_1=-3\vvec_1</m>, <m>A\vvec_2 =
-	-2\vvec_2</m>, and <m>A\vvec_3=4\vvec_3</m>.  The associated
-	eigenvalues are <m>\lambda_1 = -3</m>, <m>\lambda_2=-2</m>,
-	and <m>\lambda_3=4</m>. </p></li>
-
-	<li><p> 
-	<m>\xvec=2\vvec_1 -\vvec_2+2\vvec_3</m>. </p></li>
-
-	<li><p> We find
-	<md>
-	  \begin{alignedat}{4}
-	  A\xvec\amp{}={}\amp -6\vvec_1 \amp{}+{}\amp
-	  2\vvec_2\amp{}+{} \amp 8\vvec_3\\
-	  A^2\xvec\amp{}={}\amp 18\vvec_1\amp{}-{}\amp
-	  4\vvec_2\amp{}+{}\amp 32\vvec_3\\
-	  A^{-1}\xvec\amp{}={}\amp -\frac23\vvec_1\amp
-	  {}+{}\amp\frac12\vvec_2\amp{}+{}\amp\frac12\vvec_3\text{.} \\ 
-	  \end{alignedat}
-	</md>
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -201,6 +201,32 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> If <m>\lambda=0</m> is an eigenvalue, then there is a
+	nonzero vector <m>\vvec</m> such that <m>A\vvec=\lambda\vvec =
+	\zerovec</m>.  </p></li>
+
+	<li><p> If <m>\lambda =0</m> is an eigenvalue of <m>A</m>,
+	then there is a nonzero solution to the homogeneous
+	equation <m>A\xvec=\zerovec</m>.</p></li>
+
+	<li><p> If <m>A\vvec=\lambda\vvec</m>, we can multiply both
+	sides by <m>A^{-1}</m> and <m>\frac1\lambda</m> to obtain
+	<m>\frac1\lambda\vvec=A^{-1}\vvec</m>.
+	</p></li>
+
+	<li><p> Notice that <m>A^2\vvec =
+	A(A\vvec) = \lambda A\vvec = \lambda^2\vvec</m>, which means
+	that <m>\vvec</m> is an eigenvector with associated eigenvalue
+	<m>\lambda^2</m>. </p></li>
+
+	<li><p> The vectors <m>\vvec_1</m> and <m>\vvec_2</m> are
+	eigenvectors of <m>A^5</m> with associated eigenvalues
+	<m>\lambda_1^5 = 3^5=243</m> and <m>\lambda_2^5 = (-1)^5 =
+	-1</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If <m>\lambda=0</m> is an eigenvalue, then there is a
@@ -236,33 +262,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> If <m>\lambda=0</m> is an eigenvalue, then there is a
-	nonzero vector <m>\vvec</m> such that <m>A\vvec=\lambda\vvec =
-	\zerovec</m>.  </p></li>
 
-	<li><p> If <m>\lambda =0</m> is an eigenvalue of <m>A</m>,
-	then there is a nonzero solution to the homogeneous
-	equation <m>A\xvec=\zerovec</m>.</p></li>
-
-	<li><p> If <m>A\vvec=\lambda\vvec</m>, we can multiply both
-	sides by <m>A^{-1}</m> and <m>\frac1\lambda</m> to obtain
-	<m>\frac1\lambda\vvec=A^{-1}\vvec</m>.  
-	</p></li>
-
-	<li><p> Notice that <m>A^2\vvec =
-	A(A\vvec) = \lambda A\vvec = \lambda^2\vvec</m>, which means
-	that <m>\vvec</m> is an eigenvector with associated eigenvalue
-	<m>\lambda^2</m>. </p></li>
-
-	<li><p> The vectors <m>\vvec_1</m> and <m>\vvec_2</m> are
-	eigenvectors of <m>A^5</m> with associated eigenvalues
-	<m>\lambda_1^5 = 3^5=243</m> and <m>\lambda_2^5 = (-1)^5 =
-	-1</m>. </p></li>
-      </ol></p>
-    </answer>
-    
 	
   </exercise>
 
@@ -303,14 +303,6 @@
       </p>
     </statement>
 
-    <solution>
-      <image width="50%">
-        <prefigure xmlns="https://prefigure.org"
-                   label="pf-ex-eigen-powers-sol-sol">
-          <xi:include href="prefigure/ex-eigen-powers-sol.xml"/>
-        </prefigure>
-      </image>
-    </solution>
     <answer>
       <image width="50%">
         <prefigure xmlns="https://prefigure.org"
@@ -319,6 +311,14 @@
         </prefigure>
       </image>
     </answer>
+    <solution>
+      <image width="50%">
+        <prefigure xmlns="https://prefigure.org"
+                   label="pf-ex-eigen-powers-sol-sol">
+          <xi:include href="prefigure/ex-eigen-powers-sol.xml"/>
+        </prefigure>
+      </image>
+    </solution>
   </exercise>
 
   <exercise>
@@ -352,6 +352,28 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  Every two-dimensional vector is an eigenvector
+	  with associated eigenvalue <m>\lambda=3</m>.
+	</p></li>
+
+	<li><p> We have
+	eigenvectors <m>\vvec_1=\twovec{1}{0}</m> with associated
+	eigenvalue <m>\lambda_1=-2</m> and
+	<m>\vvec_2=\twovec{0}{1}</m> with
+	<m>\lambda_2=4</m>. </p></li>
+
+	<li><p> Every vector is an
+	eigenvector of the identity matrix with associated eigenvalue
+	<m>\lambda=1</m>. </p></li>
+
+	<li><p> The standard basis vectors <m>\evec_j</m> are
+	eigenvectors and the associated eigenvalues are the
+	corresponding diagonal entries. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The corresponding matrix transformation stretches
@@ -378,28 +400,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> 
-	  Every two-dimensional vector is an eigenvector
-	  with associated eigenvalue <m>\lambda=3</m>.
-	</p></li>
-
-	<li><p> We have
-	eigenvectors <m>\vvec_1=\twovec{1}{0}</m> with associated
-	eigenvalue <m>\lambda_1=-2</m> and
-	<m>\vvec_2=\twovec{0}{1}</m> with
-	<m>\lambda_2=4</m>. </p></li>
-
-	<li><p> Every vector is an
-	eigenvector of the identity matrix with associated eigenvalue
-	<m>\lambda=1</m>. </p></li>
-
-	<li><p> The standard basis vectors <m>\evec_j</m> are
-	eigenvectors and the associated eigenvalues are the
-	corresponding diagonal entries. </p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -435,6 +435,30 @@
 	  
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p> <m>\twovec{145}{-130}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p> <m>A\twovec10 = \twovec12</m> and
+	    <m>A\twovec01 = \twovec2{-2}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A = \begin{bmatrix}
+	      1 \amp 2 \\
+	      2 \amp -2 \\
+	      \end{bmatrix}
+	      </m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -473,31 +497,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p> <m>\twovec{145}{-130}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p> <m>A\twovec10 = \twovec12</m> and 
-	    <m>A\twovec01 = \twovec2{-2}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A = \begin{bmatrix}
-	      1 \amp 2 \\
-	      2 \amp -2 \\
-	      \end{bmatrix}
-	      </m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-    
+
   </exercise>
 	
   <exercise>
@@ -523,6 +523,15 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> False </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> True.  The associated eigenvectors are the standard
@@ -544,16 +553,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> False </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -596,6 +596,33 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  Because <m>A\vvec = \lambda\vvec</m>.
+	</p></li>
+
+	<li><p>
+	  Because <m>A\vvec = 0\vvec = \zerovec</m>.
+	</p></li>
+
+	<li><p>
+	  For the matrix <m>A</m>,
+	  <m>\vvec_1=\threevec{1}{1}{1}</m> with associated eigenvalue
+	  <m>\lambda_1=3</m>, and
+	  <m>\vvec_2=\threevec{-1}{1}{0}</m> and
+	  <m>\vvec_3=\threevec{-1}{0}{1}</m>  with
+	  associated eigenvalue <m>\lambda_2=\lambda_3 =
+	  0</m>.
+	</p>
+	<p> For <m>B</m>,
+	<m>\vvec_1=\threevec{1}{2}{3}</m>
+	with associated eigenvalue <m>\lambda_1=6</m> and
+	<m>\vvec_2=\threevec{-1}{1}{0}</m> and
+	<m>\vvec_3=\threevec{-1}{0}{1}</m> with
+	associated eigenvalue <m>\lambda_2=\lambda_3=0</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li>
@@ -637,34 +664,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  Because <m>A\vvec = \lambda\vvec</m>.
-	</p></li>
 
-	<li><p>
-	  Because <m>A\vvec = 0\vvec = \zerovec</m>.
-	</p></li>
-
-	<li><p>
-	  For the matrix <m>A</m>,
-	  <m>\vvec_1=\threevec{1}{1}{1}</m> with associated eigenvalue
-	  <m>\lambda_1=3</m>, and
-	  <m>\vvec_2=\threevec{-1}{1}{0}</m> and
-	  <m>\vvec_3=\threevec{-1}{0}{1}</m>  with
-	  associated eigenvalue <m>\lambda_2=\lambda_3 =
-	  0</m>.
-	</p>
-	<p> For <m>B</m>,
-	<m>\vvec_1=\threevec{1}{2}{3}</m> 
-	with associated eigenvalue <m>\lambda_1=6</m> and
-	<m>\vvec_2=\threevec{-1}{1}{0}</m> and
-	<m>\vvec_3=\threevec{-1}{0}{1}</m> with
-	associated eigenvalue <m>\lambda_2=\lambda_3=0</m>. </p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -686,6 +686,30 @@
       </ol> </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\twovec{1}{1}</m> with
+	associated eigenvalue <m>\lambda = 1</m> and
+	<m>\twovec{1}{-1}</m>
+	with associated
+	eigenvalue <m>\lambda=-1</m>. </p></li>
+
+	<li><p> Every two-dimensional vector is an
+	eigenvector with associated eigenvalue
+	<m>\lambda=-1</m>. </p></li>
+
+	<li><p>
+	<m>\threevec{0}{1}{0}</m> with associated
+	eigenvalue <m>\lambda=1</m>.
+	<m>\threevec{1}{0}{0}</m> and
+	<m>\threevec{0}{0}{1}</m> with associated
+	eigenvalue <m>\lambda=-1</m>. </p></li>
+
+	<li><p> <m>\threevec{1}{0}{0}</m>
+	with associated eigenvalue <m>\lambda=1</m>.
+	</p> </li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> A vector lying along the line of reflection is
@@ -715,31 +739,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\twovec{1}{1}</m> with
-	associated eigenvalue <m>\lambda = 1</m> and
-	<m>\twovec{1}{-1}</m> 
-	with associated
-	eigenvalue <m>\lambda=-1</m>. </p></li>
 
-	<li><p> Every two-dimensional vector is an
-	eigenvector with associated eigenvalue
-	<m>\lambda=-1</m>. </p></li>
-
-	<li><p> 
-	<m>\threevec{0}{1}{0}</m> with associated
-	eigenvalue <m>\lambda=1</m>.
-	<m>\threevec{1}{0}{0}</m> and
-	<m>\threevec{0}{0}{1}</m> with associated
-	eigenvalue <m>\lambda=-1</m>. </p></li>
-
-	<li><p> <m>\threevec{1}{0}{0}</m> 
-	with associated eigenvalue <m>\lambda=1</m>.
-	</p> </li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -787,6 +787,36 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\vvec_1</m>
+	with associated eigenvalue <m>\lambda_1=1.4</m>
+	and <m>\vvec_2</m> with associated
+	eigenvalue <m>\lambda_2=0.9</m>. </p></li>
+
+	<li><p> <m>\xvec_0=10\vvec_1+14\vvec_2</m>. </p></li>
+
+	<li><p> We have
+	<md>
+	  \begin{alignedat}{4}
+	  \xvec_1\amp{}={}\amp A\xvec_0 \amp {}={} 10(1.4)\vvec_1 \amp
+	  {}+{} \amp 14(0.9)\vvec_2 \\
+	  \xvec_2\amp{}={}\amp A\xvec_1 \amp {}={} 10(1.4)^2\vvec_1 \amp
+	  {}+{} \amp 14(0.9)^2\vvec_2 \\
+	  \xvec_3\amp{}={}\amp A\xvec_2 \amp {}={} 10(1.4)^3\vvec_1 \amp
+	  {}+{} \amp 14(0.9)^3\vvec_2\text{.} \\
+	  \end{alignedat}
+	</md>
+	</p></li>
+
+	<li><p> In general, <m>\xvec_k = 10(1.4)^k\vvec_1 +
+	14(0.9)^k\vvec_2</m>. </p></li>
+
+	<li><p> The ratio of <m>P_k</m> to <m>Q_k</m> is
+	1:3.</p></li>
+      </ol></p>
+
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We can compute <m>A\vvec_1 = 1.4\vvec_1</m> and
@@ -823,36 +853,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\vvec_1</m> 
-	with associated eigenvalue <m>\lambda_1=1.4</m>
-	and <m>\vvec_2</m> with associated
-	eigenvalue <m>\lambda_2=0.9</m>. </p></li>
-
-	<li><p> <m>\xvec_0=10\vvec_1+14\vvec_2</m>. </p></li>
-
-	<li><p> We have
-	<md>
-	  \begin{alignedat}{4}
-	  \xvec_1\amp{}={}\amp A\xvec_0 \amp {}={} 10(1.4)\vvec_1 \amp
-	  {}+{} \amp 14(0.9)\vvec_2 \\
-	  \xvec_2\amp{}={}\amp A\xvec_1 \amp {}={} 10(1.4)^2\vvec_1 \amp
-	  {}+{} \amp 14(0.9)^2\vvec_2 \\
-	  \xvec_3\amp{}={}\amp A\xvec_2 \amp {}={} 10(1.4)^3\vvec_1 \amp
-	  {}+{} \amp 14(0.9)^3\vvec_2\text{.} \\
-	  \end{alignedat}
-	</md>
-	</p></li>
-
-	<li><p> In general, <m>\xvec_k = 10(1.4)^k\vvec_1 +
-	14(0.9)^k\vvec_2</m>. </p></li>
-
-	<li><p> The ratio of <m>P_k</m> to <m>Q_k</m> is
-	1:3.</p></li> 
-      </ol></p>
-
-    </answer>
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises4-2.xml
+++ b/src/exercises/exercises4-2.xml
@@ -43,6 +43,27 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>(2-\lambda)^2</m>.  There is a single eigenvalue
+	<m>\lambda=2</m> having multiplicity <m>2</m>.
+	</p></li>
+
+	<li><p> <m>(3-\lambda)(4-\lambda)(-6-\lambda)</m>.  There are three
+	eigenvalues <m>\lambda=3, 4, -6</m>, each of multiplicity
+	<m>1</m>.
+	</p></li>
+
+	<li><p> <m>(-2-\lambda)^2</m>.  There is one eigenvalue
+	<m>\lambda=-2</m> having multiplicity <m>2</m>.
+	</p></li>
+
+	<li><p> <m>(3-\lambda)(-2-\lambda)</m>.  There are two eigenvalues
+	<m>\lambda=3</m> and <m>\lambda=-2</m>, each having
+	multiplicity <m>1</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The characteristic polynomial is <m>\det(A-\lambda I)
@@ -68,29 +89,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>(2-\lambda)^2</m>.  There is a single eigenvalue
-	<m>\lambda=2</m> having multiplicity <m>2</m>.
-	</p></li>
 
-	<li><p> <m>(3-\lambda)(4-\lambda)(-6-\lambda)</m>.  There are three
-	eigenvalues <m>\lambda=3, 4, -6</m>, each of multiplicity
-	<m>1</m>.
-	</p></li>
 
-	<li><p> <m>(-2-\lambda)^2</m>.  There is one eigenvalue
-	<m>\lambda=-2</m> having multiplicity <m>2</m>.
-	</p></li>
-
-	<li><p> <m>(3-\lambda)(-2-\lambda)</m>.  There are two eigenvalues
-	<m>\lambda=3</m> and <m>\lambda=-2</m>, each having
-	multiplicity <m>1</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
   <exercise>
@@ -104,6 +104,26 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> It is not possible.
+	</p></li>
+
+	<li><p> <m>
+	  \left\{
+	  \threevec100, \threevec{-1}{1}0, \threevec10{-3}
+	  \right\}
+	</m>.
+	</p></li>
+
+	<li><p> <m>\left\{\twovec10,
+	\twovec01\right\}</m>
+	</p></li>
+
+	<li><p> <m>\left\{\twovec12,\twovec{-2}1\right\}</m>
+	</p></li>
+      </ol> </p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> There is a single eigenvalue <m>\lambda=2</m> and
@@ -141,27 +161,7 @@
 	</p></li>
       </ol> </p>
     </solution>
-      
-    <answer>
-      <p><ol marker="a.">
-	<li><p> It is not possible.
-	</p></li>
 
-	<li><p> <m>
-	  \left\{
-	  \threevec100, \threevec{-1}{1}0, \threevec10{-3}
-	  \right\}
-	</m>.
-	</p></li>
-
-	<li><p> <m>\left\{\twovec10,
-	\twovec01\right\}</m>
-	</p></li>
-
-	<li><p> <m>\left\{\twovec12,\twovec{-2}1\right\}</m>
-	</p></li>
-      </ol> </p>
-    </answer>
 
   </exercise>
 
@@ -188,6 +188,15 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> False.  This is true for a diagonal matrix, but it is
@@ -219,15 +228,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -268,6 +268,28 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>  <m>\lambda=-6,6,-10</m>.
+	</p></li>
+
+	<li><p> The standard basis vectors <m>\evec_j</m> are
+	eigenvectors associated to the diagonal entries.
+	</p></li>
+
+	<li><p> Yes.
+	</p></li>
+
+	<li><p> <m>\lambda=0,2,-2</m>.  The matrix <m>A</m> is not
+	invertible, but there is a basis for <m>\real^3</m> consisting
+	of eigenvectors of <m>A</m>.
+	</p></li>
+
+	<li><p> <m>\det(A^2-\lambda I) =
+	(16-\lambda)(4-\lambda)(1-\lambda)</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p>  If <m>A\vvec=\lambda\vvec</m>, then <m>2A\vvec =
@@ -304,28 +326,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p>  <m>\lambda=-6,6,-10</m>.
-	</p></li>
-
-	<li><p> The standard basis vectors <m>\evec_j</m> are
-	eigenvectors associated to the diagonal entries.
-	</p></li>
-
-	<li><p> Yes.  
-	</p></li>
-
-	<li><p> <m>\lambda=0,2,-2</m>.  The matrix <m>A</m> is not
-	invertible, but there is a basis for <m>\real^3</m> consisting
-	of eigenvectors of <m>A</m>.
-	</p></li>
-
-	<li><p> <m>\det(A^2-\lambda I) =
-	(16-\lambda)(4-\lambda)(1-\lambda)</m>.
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -374,6 +374,26 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> A basis of eigenvectors is
+	<md>
+	  \left\{\threevec012, \threevec10{-1},
+	  \threevec{-2}{1}{3}\right\}\text{.}
+	</md>
+	</p></li>
+
+	<li><p> It is not possible to find a basis of eigenvectors.
+	</p></li>
+
+	<li><p> A basis of eigenvectors is
+	<md>
+	  \left\{\threevec{-2}32, \threevec10{-1},
+	  \threevec012\right\}\text{.}
+	</md>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Sage tells us there are three distinct eigenvalues
@@ -401,28 +421,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> A basis of eigenvectors is
-	<md>
-	  \left\{\threevec012, \threevec10{-1},
-	  \threevec{-2}{1}{3}\right\}\text{.}
-	</md>
-	</p></li>
 
-	<li><p> It is not possible to find a basis of eigenvectors.
-	</p></li>
-	
-	<li><p> A basis of eigenvectors is 
-	<md>
-	  \left\{\threevec{-2}32, \threevec10{-1},
-	  \threevec012\right\}\text{.}
-	</md>
-	</p></li>
-      </ol></p>
-    </answer>
-	  
+
   </exercise>
 
   <exercise>
@@ -466,6 +466,16 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Both equal <m>-3</m>. </p></li>
+	<li><p> Both equal <m>12</m>. </p></li>
+	<li><p> <m>\det A</m> equals the product of the
+	eigenvalues. </p></li>
+	<li><p> We see that <m>\det A =
+	\lambda_1\lambda_2\ldots\lambda_n</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have <m>\det A = -3</m>, and the product of the
@@ -494,17 +504,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Both equal <m>-3</m>. </p></li>
-	<li><p> Both equal <m>12</m>. </p></li>
-	<li><p> <m>\det A</m> equals the product of the
-	eigenvalues. </p></li>
-	<li><p> We see that <m>\det A =
-	\lambda_1\lambda_2\ldots\lambda_n</m>. </p></li>
-      </ol></p>
-    </answer>
-      
+
   </exercise>
 
   <exercise>
@@ -540,6 +540,32 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\lambda_1=1.1</m> with
+	associated eigenvector <m>\vvec_1=\twovec11</m> and
+	<m>\lambda_2=0.8</m> with associated eigenvector
+	<m>\vvec_2=\twovec21</m>.
+	</p></li>
+
+	<li><p> <m>\xvec_0=\vvec_1+5\vvec_2</m>.
+	</p></li>
+
+	<li><p> We have
+	<md>
+	  \begin{aligned}
+	  \xvec_1 \amp {}={} 1.1\vvec_1+0.8\cdot5\vvec_2 \\
+	  \xvec_2 \amp {}={} 1.1^2\vvec_1+0.8^2\cdot5\vvec_2 \\
+	  \xvec_3 \amp {}={} 1.1^3\vvec_1+0.8^3\cdot5\vvec_2 \\
+	  \end{aligned}
+	</md>.
+	</p></li>
+
+	<li><p>
+	<m>\xvec_k \approx \twovec{1.1^k}{1.1^k}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We find the eigenvalues <m>\lambda_1=1.1</m> with
@@ -573,32 +599,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\lambda_1=1.1</m> with
-	associated eigenvector <m>\vvec_1=\twovec11</m> and
-	<m>\lambda_2=0.8</m> with associated eigenvector
-	<m>\vvec_2=\twovec21</m>. 
-	</p></li>
-
-	<li><p> <m>\xvec_0=\vvec_1+5\vvec_2</m>.
-	</p></li>
-
-	<li><p> We have
-	<md>
-	  \begin{aligned}
-	  \xvec_1 \amp {}={} 1.1\vvec_1+0.8\cdot5\vvec_2 \\
-	  \xvec_2 \amp {}={} 1.1^2\vvec_1+0.8^2\cdot5\vvec_2 \\
-	  \xvec_3 \amp {}={} 1.1^3\vvec_1+0.8^3\cdot5\vvec_2 \\
-	  \end{aligned}
-	</md>.	  
-	</p></li>
-
-	<li><p> 
-	<m>\xvec_k \approx \twovec{1.1^k}{1.1^k}</m>.
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -635,6 +635,33 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\lambda_1=1</m> with associated
+	eigenvector <m>\vvec_1=\twovec12</m> and <m>\lambda_2=0.1</m> with
+	associated eigenvector <m>\vvec_2=\twovec{-1}{1}</m>.
+	</p></li>
+
+	<li><p>
+	<m>\xvec_0=\frac13\vvec_1+\frac13\vvec_2</m>.
+	</p></li>
+
+	<li><p> We have
+	<md>
+	  \begin{aligned}
+	  \xvec_1 \amp {}={} \frac13\vvec_1+0.1\frac13\vvec_2 \\
+	  \xvec_2 \amp {}={} \frac13\vvec_1+0.1^2\frac13\vvec_2 \\
+	  \xvec_3 \amp {}={} \frac13\vvec_1+0.1^3\frac13\vvec_2 \\
+	  \end{aligned}
+	</md>.
+	</p></li>
+
+	<li><p>
+	<m>\xvec_k \approx
+	\twovec{\frac13}{\frac23}</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have eigenvalues <m>\lambda_1=1</m> with associated
@@ -666,33 +693,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\lambda_1=1</m> with associated
-	eigenvector <m>\vvec_1=\twovec12</m> and <m>\lambda_2=0.1</m> with
-	associated eigenvector <m>\vvec_2=\twovec{-1}{1}</m>.
-	</p></li>
-
-	<li><p> 
-	<m>\xvec_0=\frac13\vvec_1+\frac13\vvec_2</m>.
-	</p></li>
-
-	<li><p> We have
-	<md>
-	  \begin{aligned}
-	  \xvec_1 \amp {}={} \frac13\vvec_1+0.1\frac13\vvec_2 \\
-	  \xvec_2 \amp {}={} \frac13\vvec_1+0.1^2\frac13\vvec_2 \\
-	  \xvec_3 \amp {}={} \frac13\vvec_1+0.1^3\frac13\vvec_2 \\
-	  \end{aligned}
-	</md>.	  
-	</p></li>
-
-	<li><p> 
-	<m>\xvec_k \approx 
-	\twovec{\frac13}{\frac23}</m>. 
-	</p></li>
-      </ol></p>
-    </answer>
 
     
   </exercise>

--- a/src/exercises/exercises4-3.xml
+++ b/src/exercises/exercises4-3.xml
@@ -53,6 +53,51 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	  <m>P = \mattwo12{-1}1</m> and <m>D=\mattwo200{-3}</m>
+	</p></li>
+
+	<li><p> <m>A</m> is not
+	diagonalizable. </p></li>
+
+	<li><p> <m>A</m> is not
+	diagonalizable. </p></li>
+
+	<li><p>
+	  <m>
+	  P = \left[\begin{array}{rrr}
+	  9 \amp 0 \amp 0 \\
+	  6 \amp 6 \amp 0 \\
+	  -2 \amp -1 \amp 1 \\
+	  \end{array}\right]
+	  </m> and
+	  <m>D = \left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  0 \amp -2 \amp 0 \\
+	  0 \amp 0 \amp 4 \\
+	  \end{array}\right]
+	  </m>
+	</p></li>
+
+	<li><p>
+	<m>
+	  P = \left[\begin{array}{rrr}
+	  1 \amp -1 \amp 0 \\
+	  1 \amp 0 \amp -1 \\
+	  1 \amp 1 \amp 1 \\
+	  \end{array}\right]
+	</m> and
+	<m>D = \left[\begin{array}{rrr}
+	  5 \amp 0 \amp 0 \\
+	  0 \amp -1 \amp 0 \\
+	  0 \amp 0 \amp -1 \\
+	  \end{array}\right]
+	</m>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We find that <m>\vvec_1=\twovec{1}{-2}</m> is an
@@ -115,53 +160,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p><ol marker="a.">
-	<li><p>
-	  <m>P = \mattwo12{-1}1</m> and <m>D=\mattwo200{-3}</m>
-	</p></li>
 
-	<li><p> <m>A</m> is not
-	diagonalizable. </p></li>
 
-	<li><p> <m>A</m> is not
-	diagonalizable. </p></li>
-
-	<li><p>
-	  <m>
-	  P = \left[\begin{array}{rrr}
-	  9 \amp 0 \amp 0 \\
-	  6 \amp 6 \amp 0 \\
-	  -2 \amp -1 \amp 1 \\
-	  \end{array}\right]
-	  </m> and 
-	  <m>D = \left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\
-	  0 \amp -2 \amp 0 \\
-	  0 \amp 0 \amp 4 \\
-	  \end{array}\right]
-	  </m>
-	</p></li>
-
-	<li><p> 
-	<m>
-	  P = \left[\begin{array}{rrr}
-	  1 \amp -1 \amp 0 \\
-	  1 \amp 0 \amp -1 \\
-	  1 \amp 1 \amp 1 \\
-	  \end{array}\right]
-	</m> and
-	<m>D = \left[\begin{array}{rrr}
-	  5 \amp 0 \amp 0 \\
-	  0 \amp -1 \amp 0 \\
-	  0 \amp 0 \amp -1 \\
-	  \end{array}\right]
-	</m>
-	</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -197,6 +197,14 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> There are two real eigenvalues. </p></li>
+	<li><p> There is a single real eigenvalue. </p></li>
+	<li><p> <m>C=\mattwo1{-2}21</m> or
+	<m>C=\mattwo12{-2}1</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have two real eigenvalues <m>\lambda=2,
@@ -211,15 +219,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> There are two real eigenvalues. </p></li>
-	<li><p> There is a single real eigenvalue. </p></li>
-	<li><p> <m>C=\mattwo1{-2}21</m> or
-	<m>C=\mattwo12{-2}1</m>. </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -246,6 +246,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> False.  A matrix can be invertible without us being
@@ -271,15 +280,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -315,6 +315,15 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Yes </p></li>
+	<li><p> No </p></li>
+	<li><p> Yes </p></li>
+	<li><p> Only the identity </p></li>
+	<li><p> <m>A=\mattwo4004</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Yes.  If <m>A</m> has <m>3</m> real and distinct
@@ -338,16 +347,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Yes </p></li>
-	<li><p> No </p></li>
-	<li><p> Yes </p></li>
-	<li><p> Only the identity </p></li>
-	<li><p> <m>A=\mattwo4004</m>. </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -402,6 +402,34 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Multiplying by <m>A</m> uniformly stretches vectors by
+	a factor of <m>2</m>. </p></li>
+
+	<li><p> This is a shear so that vectors are stretched and then
+	pushed horizontally. </p></li>
+
+	<li><p> We write <m>(a,b) = (3,6) = (r\cos\theta,
+	r\sin\theta)</m> where <m>r=3\sqrt{5}</m> and <m>\theta =
+	\arctan(2)</m>.  Therefore, <m>A</m> will stretch vectors by a
+	factor of <m>3\sqrt{5}</m> and rotate them by <m>\theta\approx
+	63.4^\circ</m>. </p></li>
+
+	<li><p> Vectors are stretched in the horizontal direction by a
+	factor of <m>4</m> and stretched vertically by a factor of
+	<m>2</m> before being reflected in the horizontal
+	axis. </p></li>
+
+	<li><p> This matrix has eigenvectors <m>\vvec_1=\twovec11</m>
+	with associated eigenvalue <m>\lambda_1=4</m> and
+	<m>\vvec_2=\twovec{-1}{1}</m> with <m>\lambda_2=-2</m>.
+	Therefore, <m>A</m> stretches vectors by a factor of <m>4</m>
+	in the direction of <m>\vvec_1</m> and a factor of <m>2</m> in
+	the direction of <m>\vvec_1</m> before reflecting in the line
+	defined by <m>\vvec_1</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Multiplying by <m>A</m> uniformly stretches vectors by
@@ -431,34 +459,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Multiplying by <m>A</m> uniformly stretches vectors by
-	a factor of <m>2</m>. </p></li>
-
-	<li><p> This is a shear so that vectors are stretched and then
-	pushed horizontally. </p></li>
-
-	<li><p> We write <m>(a,b) = (3,6) = (r\cos\theta,
-	r\sin\theta)</m> where <m>r=3\sqrt{5}</m> and <m>\theta =
-	\arctan(2)</m>.  Therefore, <m>A</m> will stretch vectors by a
-	factor of <m>3\sqrt{5}</m> and rotate them by <m>\theta\approx
-	63.4^\circ</m>. </p></li>
-
-	<li><p> Vectors are stretched in the horizontal direction by a
-	factor of <m>4</m> and stretched vertically by a factor of
-	<m>2</m> before being reflected in the horizontal
-	axis. </p></li>
-
-	<li><p> This matrix has eigenvectors <m>\vvec_1=\twovec11</m>
-	with associated eigenvalue <m>\lambda_1=4</m> and
-	<m>\vvec_2=\twovec{-1}{1}</m> with <m>\lambda_2=-2</m>.
-	Therefore, <m>A</m> stretches vectors by a factor of <m>4</m>
-	in the direction of <m>\vvec_1</m> and a factor of <m>2</m> in
-	the direction of <m>\vvec_1</m> before reflecting in the line
-	defined by <m>\vvec_1</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -488,6 +488,38 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> If <m>A=PBP^{-1}</m>, then <m>B=P^{-1}AP</m>.  If we
+	call <m>Q=P^{-1}</m>, then <m>B=QAQ^{-1}</m>, which shows that
+	<m>B</m> is similar to <m>A</m>. </p></li>
+
+	<li><p> If <m>A=PBP^{-1}</m> and <m>B=QCQ^{-1}</m>, then
+	<m>A=PQCP^{-1}Q^{-1} = (PQ)C(PQ)^{-1}</m>, which shows that
+	<m>A</m> is similar to <m>C</m>. </p></li>
+
+	<li><p> If <m>B</m> is diagonalizable, then it is similar to a
+	diagonal matrix <m>D</m>.  Since <m>A</m> is similar to
+	<m>B</m> and <m>B</m> is similar to <m>D</m>, we know that
+	<m>A</m> is also similar to <m>D</m> so that <m>A</m> is
+	diagonalizable. </p></li>
+
+	<li><p> If <m>A=PBP^{-1}</m>, then
+	<md>
+	  \begin{aligned}
+	  \det(A-\lambda I) \amp = \det(PBP^{-1}-\lambda PP^{-1}) \\
+	  \amp = \det[P(B-\lambda I)P^{-1}] \\
+	  \amp = \det(B-\lambda I)\text{.} \\
+	  \end{aligned}
+	</md>
+	</p></li>
+
+	<li><p> The eigenvalues of a matrix are the roots of its
+	characteristic polynomial.  If <m>A</m> and <m>B</m> are
+	similar, then they have the same characteristic polynomial and
+	hence the same eigenvalues. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If <m>A=PBP^{-1}</m>, then <m>B=P^{-1}AP</m>.  If we
@@ -521,38 +553,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> If <m>A=PBP^{-1}</m>, then <m>B=P^{-1}AP</m>.  If we
-	call <m>Q=P^{-1}</m>, then <m>B=QAQ^{-1}</m>, which shows that
-	<m>B</m> is similar to <m>A</m>. </p></li>
-
-	<li><p> If <m>A=PBP^{-1}</m> and <m>B=QCQ^{-1}</m>, then
-	<m>A=PQCP^{-1}Q^{-1} = (PQ)C(PQ)^{-1}</m>, which shows that
-	<m>A</m> is similar to <m>C</m>. </p></li>
-
-	<li><p> If <m>B</m> is diagonalizable, then it is similar to a
-	diagonal matrix <m>D</m>.  Since <m>A</m> is similar to
-	<m>B</m> and <m>B</m> is similar to <m>D</m>, we know that
-	<m>A</m> is also similar to <m>D</m> so that <m>A</m> is
-	diagonalizable. </p></li>
-
-	<li><p> If <m>A=PBP^{-1}</m>, then
-	<md>
-	  \begin{aligned}
-	  \det(A-\lambda I) \amp = \det(PBP^{-1}-\lambda PP^{-1}) \\
-	  \amp = \det[P(B-\lambda I)P^{-1}] \\
-	  \amp = \det(B-\lambda I)\text{.} \\
-	  \end{aligned}
-	</md>
-	</p></li>
-
-	<li><p> The eigenvalues of a matrix are the roots of its
-	characteristic polynomial.  If <m>A</m> and <m>B</m> are
-	similar, then they have the same characteristic polynomial and
-	hence the same eigenvalues. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -583,6 +583,20 @@
       </p>
     </statement> 
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> The matrix <m>D</m> projects vectors onto the
+	horizontal axis.</p></li>
+
+	<li><p> <m>A</m> projects vectors onto the line defined by the
+	eigenvector
+	<m>\twovec12</m>. </p></li>
+
+	<li><p> <m>A^k=A</m>. </p></li>
+
+	<li><p> No </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The matrix <m>D</m> projects vectors onto the
@@ -602,22 +616,8 @@
 	an eigenvalue.</p></li>
       </ol></p>
     </solution>
-    
-    <answer>
-      <p><ol marker="a.">
-	<li><p> The matrix <m>D</m> projects vectors onto the
-	horizontal axis.</p></li>
 
-	<li><p> <m>A</m> projects vectors onto the line defined by the
-	eigenvector
-	<m>\twovec12</m>. </p></li>
 
-	<li><p> <m>A^k=A</m>. </p></li>
-
-	<li><p> No </p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise xml:id="exercise-complex-eigenvector">
@@ -667,6 +667,22 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\lambda = 3\pm i</m>. </p></li>
+
+	<li><p> If <m>\lambda=3+i</m>, then
+	<m>C=\mattwo3{-1}13</m>. </p></li>
+
+	<li><p>
+	  <m>\vvec = \twovec{1-i}{1}</m> </p></li>
+
+	<li><p> <m>\vvec_1=\twovec11</m> and
+	<m>\vvec_2=\twovec{1}{0}</m>. </p></li>
+
+	<li><p> <m>P = \mattwo1110</m></p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The eigenvalues are <m>\lambda = 3\pm i</m>. </p></li>
@@ -692,22 +708,6 @@
 
       </ol></p>
     </solution>
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\lambda = 3\pm i</m>. </p></li>
-
-	<li><p> If <m>\lambda=3+i</m>, then
-	<m>C=\mattwo3{-1}13</m>. </p></li>
-
-	<li><p> 
-	  <m>\vvec = \twovec{1-i}{1}</m> </p></li>
-
-	<li><p> <m>\vvec_1=\twovec11</m> and
-	<m>\vvec_2=\twovec{1}{0}</m>. </p></li> 
-
-	<li><p> <m>P = \mattwo1110</m></p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -813,6 +813,51 @@
       </p>
     </statement>
 
+    <answer>
+      <p> In each case, the vectors are rotated by <m>90^\circ</m>.
+      Note that the figures below are draw at different scales.
+	<ol marker="a.">
+	<li> <sidebyside widths="40% 40%">
+	  <p> The vectors are stretched by a factor of 1.4. </p>
+	  <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-comp-power-a-ans">
+              <xi:include href="prefigure/ex-comp-power-a.xml"/>
+            </prefigure>
+          </image>
+	</sidebyside>
+	</li>
+	<li> <sidebyside widths="40% 40%">
+	  <p> The vectors are stretched by a factor of 0.8. </p>
+	  <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-comp-power-b-ans">
+              <xi:include href="prefigure/ex-comp-power-b.xml"/>
+            </prefigure>
+          </image>
+	</sidebyside>
+	</li>
+	<li> <sidebyside widths="40% 40%">
+	  <p> The length of the vectors is unchanged. </p>
+	  <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-comp-power-c-ans">
+              <xi:include href="prefigure/ex-comp-power-c.xml"/>
+            </prefigure>
+          </image>
+	</sidebyside>
+	</li>
+	<li><p> For different values of <m>r</m>,
+	<ol marker="i.">
+	  <li><p> The vectors are pulled into the origin as their
+	  lengths become increasingly small. </p></li>
+	  <li><p> The length of the vectors is unchanged. </p></li>
+	  <li><p> The vectors are pushed away from the origin as their
+	  lengths become increasingly large. </p></li>
+	</ol>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p> In each case, the vectors are rotated by <m>90^\circ</m>.
       Note that the figures below are draw at different scales.
@@ -859,51 +904,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p> In each case, the vectors are rotated by <m>90^\circ</m>.
-      Note that the figures below are draw at different scales.
-	<ol marker="a.">
-	<li> <sidebyside widths="40% 40%">
-	  <p> The vectors are stretched by a factor of 1.4. </p>
-	  <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-comp-power-a-ans">
-              <xi:include href="prefigure/ex-comp-power-a.xml"/>
-            </prefigure>
-          </image>
-	</sidebyside>
-	</li>
-	<li> <sidebyside widths="40% 40%">
-	  <p> The vectors are stretched by a factor of 0.8. </p>
-	  <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-comp-power-b-ans">
-              <xi:include href="prefigure/ex-comp-power-b.xml"/>
-            </prefigure>
-          </image>
-	</sidebyside>
-	</li>
-	<li> <sidebyside widths="40% 40%">
-	  <p> The length of the vectors is unchanged. </p>
-	  <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-comp-power-c-ans">
-              <xi:include href="prefigure/ex-comp-power-c.xml"/>
-            </prefigure>
-          </image>
-	</sidebyside>
-	</li>
-	<li><p> For different values of <m>r</m>,
-	<ol marker="i.">
-	  <li><p> The vectors are pulled into the origin as their
-	  lengths become increasingly small. </p></li>
-	  <li><p> The length of the vectors is unchanged. </p></li>
-	  <li><p> The vectors are pushed away from the origin as their
-	  lengths become increasingly large. </p></li>
-	</ol>
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -1044,6 +1044,48 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li>
+	  <image width="40%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-power-a-ans">
+              <xi:include href="prefigure/ex-power-a.xml"/>
+            </prefigure>
+          </image>
+	</li>
+
+	<li>
+	  <image width="40%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-power-b-ans">
+              <xi:include href="prefigure/ex-power-b.xml"/>
+            </prefigure>
+          </image>
+        </li>
+
+	<li>
+	  <image width="40%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-power-c-ans">
+              <xi:include href="prefigure/ex-power-c.xml"/>
+            </prefigure>
+          </image>
+	</li>
+
+	<li>
+	  <image width="40%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-power-d-ans">
+              <xi:include href="prefigure/ex-power-d.xml"/>
+            </prefigure>
+          </image>
+	</li>
+
+	<li><p> Vectors will be pulled into the
+	origin. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li>
@@ -1108,48 +1150,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li>
-	  <image width="40%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-power-a-ans">
-              <xi:include href="prefigure/ex-power-a.xml"/>
-            </prefigure>
-          </image>
-	</li>
-
-	<li>
-	  <image width="40%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-power-b-ans">
-              <xi:include href="prefigure/ex-power-b.xml"/>
-            </prefigure>
-          </image>
-        </li>
-
-	<li>
-	  <image width="40%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-power-c-ans">
-              <xi:include href="prefigure/ex-power-c.xml"/>
-            </prefigure>
-          </image>
-	</li>
-
-	<li>
-	  <image width="40%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-power-d-ans">
-              <xi:include href="prefigure/ex-power-d.xml"/>
-            </prefigure>
-          </image>
-	</li>
-
-	<li><p> Vectors will be pulled into the
-	origin. </p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
   

--- a/src/exercises/exercises4-4.xml
+++ b/src/exercises/exercises4-4.xml
@@ -41,6 +41,14 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Repellor </p></li>
+	<li><p> Spiral repellor </p></li>
+	<li><p> Saddle </p></li>
+	<li><p> Attractor </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> There are two real eigenvalues <m>\lambda_1=4</m> and
@@ -130,14 +138,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Repellor </p></li>
-	<li><p> Spiral repellor </p></li>
-	<li><p> Saddle </p></li>
-	<li><p> Attractor </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -254,6 +254,65 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p> The phase portraits are as shown.
+	<ol marker="a.">
+	<li><p> When <m>p=\frac12</m>.</p>
+	<sidebyside widths="45% 45%">
+          <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-phase-param-a-a-ans">
+              <xi:include href="prefigure/ex-phase-param-a-a.xml"/>
+            </prefigure>
+          </image>
+          <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-phase-param-a-b-ans">
+              <xi:include href="prefigure/ex-phase-param-a-b.xml"/>
+            </prefigure>
+          </image>
+	</sidebyside>
+        </li>
+
+	<li><p> When <m>p=1</m>.</p>
+	<sidebyside widths="45% 45%">
+          <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-phase-param-b-a-ans">
+              <xi:include href="prefigure/ex-phase-param-b-a.xml"/>
+            </prefigure>
+          </image>
+          <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-phase-param-b-b-ans">
+              <xi:include href="prefigure/ex-phase-param-b-b.xml"/>
+            </prefigure>
+          </image>
+	</sidebyside>
+        </li>
+	<li><p> When <m>p=2</m>.</p>
+	<sidebyside widths="45% 45%">
+          <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-phase-param-c-a-ans">
+              <xi:include href="prefigure/ex-phase-param-c-a.xml"/>
+            </prefigure>
+          </image>
+          <image>
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-phase-param-c-b-ans">
+              <xi:include href="prefigure/ex-phase-param-c-b.xml"/>
+            </prefigure>
+          </image>
+	</sidebyside>
+        </li>
+
+	<li><p> If <m>p\lt1</m>, we have an attractor.  If
+	<m>p\gt1</m>, we have a saddle.  The transition between the
+	two types occurs at <m>p=1</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p> The phase portraits are as shown.
 	<ol marker="a.">
@@ -314,67 +373,8 @@
 	</p></li>
       </ol></p>
     </solution>
-	
-    <answer>
-      <p> The phase portraits are as shown.
-	<ol marker="a.">
-	<li><p> When <m>p=\frac12</m>.</p>
-	<sidebyside widths="45% 45%">
-          <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-phase-param-a-a-ans">
-              <xi:include href="prefigure/ex-phase-param-a-a.xml"/>
-            </prefigure>
-          </image>
-          <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-phase-param-a-b-ans">
-              <xi:include href="prefigure/ex-phase-param-a-b.xml"/>
-            </prefigure>
-          </image>
-	</sidebyside>
-        </li>
-	
-	<li><p> When <m>p=1</m>.</p>
-	<sidebyside widths="45% 45%">
-          <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-phase-param-b-a-ans">
-              <xi:include href="prefigure/ex-phase-param-b-a.xml"/>
-            </prefigure>
-          </image>
-          <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-phase-param-b-b-ans">
-              <xi:include href="prefigure/ex-phase-param-b-b.xml"/>
-            </prefigure>
-          </image>
-	</sidebyside>
-        </li>	
-	<li><p> When <m>p=2</m>.</p>
-	<sidebyside widths="45% 45%">
-          <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-phase-param-c-a-ans">
-              <xi:include href="prefigure/ex-phase-param-c-a.xml"/>
-            </prefigure>
-          </image>
-          <image>
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-phase-param-c-b-ans">
-              <xi:include href="prefigure/ex-phase-param-c-b.xml"/>
-            </prefigure>
-          </image>
-	</sidebyside>
-        </li>
 
-	<li><p> If <m>p\lt1</m>, we have an attractor.  If
-	<m>p\gt1</m>, we have a saddle.  The transition between the
-	two types occurs at <m>p=1</m>.
-	</p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -472,6 +472,23 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\lambda_1=\frac12</m> and <m>\lambda_2=2</m></p>
+	<image source="images/ex-predator-sol-a" width="90%" />
+	</li>
+
+	<li><p> <m>\lambda_1=1</m> and <m>\lambda_2=1.5</m></p>
+	<image source="images/ex-predator-sol-b" width="90%"/>
+	</li>
+
+	<li><p> <m>p\lt 1</m> </p></li>
+
+	<li><p> As <m>p</m> grows, there needs to be a sufficient
+	<m>S</m> population to
+	ensure the survival of both species. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If <m>p = 0</m>, the eigenvectors are
@@ -556,24 +573,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\lambda_1=\frac12</m> and <m>\lambda_2=2</m></p>
-	<image source="images/ex-predator-sol-a" width="90%" />
-	</li>
-	
-	<li><p> <m>\lambda_1=1</m> and <m>\lambda_2=1.5</m></p>
-	<image source="images/ex-predator-sol-b" width="90%"/>
-	</li>
 
-	<li><p> <m>p\lt 1</m> </p></li>
-
-	<li><p> As <m>p</m> grows, there needs to be a sufficient
-	<m>S</m> population to 
-	ensure the survival of both species. </p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -616,6 +616,32 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> This
+	dynamical system is a center. </p></li>
+
+	<li><p> <m>E=\left[\begin{array}{rr}
+	0 \amp -1 \\
+	1 \amp 0 \\
+	\end{array}\right]</m>.
+	</p></li>
+
+	<li><p> <m>A^4=I</m>. </p></li>
+
+	<li><p> <m>\lambda=\frac12\pm
+	\frac{\sqrt{3}}2 i</m>. </p></li>
+
+	<li><p>
+	<m>E=\left[\begin{array}{rr}
+	\frac 12 \amp -\frac{\sqrt{3}}2 \\
+	\frac{\sqrt{3}}2 \amp \frac 12 \\
+	\end{array}\right]</m>
+	</p></li>
+
+	<li><p> <m>B^6=I</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The eigenvalues are <m>\lambda=\pm i</m> so this
@@ -645,33 +671,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> This
-	dynamical system is a center. </p></li>
 
-	<li><p> <m>E=\left[\begin{array}{rr}
-	0 \amp -1 \\
-	1 \amp 0 \\
-	\end{array}\right]</m>.
-	</p></li>
-
-	<li><p> <m>A^4=I</m>. </p></li>
-
-	<li><p> <m>\lambda=\frac12\pm
-	\frac{\sqrt{3}}2 i</m>. </p></li>
-
-	<li><p> 
-	<m>E=\left[\begin{array}{rr}
-	\frac 12 \amp -\frac{\sqrt{3}}2 \\
-	\frac{\sqrt{3}}2 \amp \frac 12 \\
-	\end{array}\right]</m>
-	</p></li>
-
-	<li><p> <m>B^6=I</m>. </p></li>
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <exercise>
@@ -713,6 +713,32 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> If we write <m>\xvec_k=\threevec{J_k}{Y_k}{A_k}</m>,
+	we have
+	<md>
+	  \xvec_{k+1} = \left[\begin{array}{rrr}
+	  0 \amp 0 \amp 0.5 \\
+	  0.9 \amp 0 \amp 0 \\
+	  0.6 \amp 0.8 \amp 0 \\
+	  \end{array}\right]
+	  \xvec_k\text{.}
+	</md>
+	</p></li>
+
+	<li><p> <m>\lambda_1 = 0.85</m> and
+	<m>\lambda_{2,3} = -0.43\pm 0.49i</m>. </p></li>
+
+	<li><p> The populations will eventually become
+	extinct. </p></li>
+
+	<li><p> All the populations grow by <m>2</m>%, and
+	there are about <m>78</m>
+	juveniles and <m>69</m> yearlings for every <m>100</m> adults.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If we write <m>\xvec_k=\threevec{J_k}{Y_k}{A_k}</m>,
@@ -744,32 +770,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> If we write <m>\xvec_k=\threevec{J_k}{Y_k}{A_k}</m>,
-	we have
-	<md>
-	  \xvec_{k+1} = \left[\begin{array}{rrr}
-	  0 \amp 0 \amp 0.5 \\
-	  0.9 \amp 0 \amp 0 \\
-	  0.6 \amp 0.8 \amp 0 \\
-	  \end{array}\right]
-	  \xvec_k\text{.}
-	</md>
-	</p></li>
-
-	<li><p> <m>\lambda_1 = 0.85</m> and
-	<m>\lambda_{2,3} = -0.43\pm 0.49i</m>. </p></li>
-
-	<li><p> The populations will eventually become
-	extinct. </p></li>
-
-	<li><p> All the populations grow by <m>2</m>%, and
-	there are about <m>78</m>
-	juveniles and <m>69</m> yearlings for every <m>100</m> adults.
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -801,6 +801,15 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> False.  We know that the dynamical system is either a
@@ -825,16 +834,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -912,6 +912,51 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>A
+	= \left[\begin{array}{rr}
+	1 \amp 1 \\
+	1 \amp 0 \\
+	\end{array}\right]
+	</m>
+	</p></li>
+
+	<li><p> Find the roots of the characteristic polynomial.
+	</p></li>
+
+	<li><p> <m>A</m> defines a saddle. </p></li>
+
+	<li><p> <m>\xvec_0 = \frac1{\sqrt{5}}\vvec_1
+	-\frac1{\sqrt{5}}\vvec_2</m>.
+	</p></li>
+
+	<li><p> We have
+	<m>
+	  \xvec_n =
+	  \frac1{\sqrt5}\left(\frac{1+\sqrt5}{2}\right)^n
+	  \twovec{\lambda_1}{1} -
+	  \frac1{\sqrt5}\left(\frac{1-\sqrt5}{2}\right)^n
+	  \twovec{\lambda_2}{1}
+	</m>.
+	</p></li>
+
+	<li><p>
+	From the second component, we see that
+	<md>F_{n} = \frac{1}{\sqrt{5}}\left[
+	\left(\frac{1+\sqrt{5}}{2}\right)^n -
+	\left(\frac{1-\sqrt{5}}{2}\right)^n\right]\text{.}
+	</md>
+	</p></li>
+
+	<li><p> <m>F_{20} = 6765</m> </p></li>
+
+	<li><p> For large values of <m>n</m>, we have
+	<m>\xvec_n\approx\frac1{\sqrt5}\lambda_1^n\twovec{\lambda_1}{1}</m>.
+	</p></li>
+
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have
@@ -981,51 +1026,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>A
-	= \left[\begin{array}{rr}
-	1 \amp 1 \\
-	1 \amp 0 \\
-	\end{array}\right]
-	</m>
-	</p></li>
-
-	<li><p> Find the roots of the characteristic polynomial.
-	</p></li>
-
-	<li><p> <m>A</m> defines a saddle. </p></li>
-
-	<li><p> <m>\xvec_0 = \frac1{\sqrt{5}}\vvec_1
-	-\frac1{\sqrt{5}}\vvec_2</m>.
-	</p></li>
-
-	<li><p> We have
-	<m>
-	  \xvec_n =
-	  \frac1{\sqrt5}\left(\frac{1+\sqrt5}{2}\right)^n
-	  \twovec{\lambda_1}{1} - 
-	  \frac1{\sqrt5}\left(\frac{1-\sqrt5}{2}\right)^n
-	  \twovec{\lambda_2}{1}
-	</m>.
-	</p></li>
-
-	<li><p>
-	From the second component, we see that
-	<md>F_{n} = \frac{1}{\sqrt{5}}\left[
-	\left(\frac{1+\sqrt{5}}{2}\right)^n -
-	\left(\frac{1-\sqrt{5}}{2}\right)^n\right]\text{.}
-	</md>
-	</p></li>
-
-	<li><p> <m>F_{20} = 6765</m> </p></li>
-
-	<li><p> For large values of <m>n</m>, we have
-	<m>\xvec_n\approx\frac1{\sqrt5}\lambda_1^n\twovec{\lambda_1}{1}</m>.
-	</p></li>
-	
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -1062,6 +1062,20 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\xvec_0 = \vvec_1+\vvec_2</m>. </p></li>
+
+	<li><p> <m>\xvec_n = A^n\xvec_0 =
+	\lambda_1^n\vvec_1 + \lambda_2^n\vvec_2</m>
+	</p></li>
+
+	<li><p> Because <m>|\lambda_2| \lt 1</m>, larger powers
+	<m>\lambda_2^n</m> are very close to zero.  </p></li>
+
+	<li><p> <m>L_{20} = 15127</m>.</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Constructing the augmented matrix and row reducing
@@ -1082,20 +1096,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\xvec_0 = \vvec_1+\vvec_2</m>. </p></li>
-
-	<li><p> <m>\xvec_n = A^n\xvec_0 =
-	\lambda_1^n\vvec_1 + \lambda_2^n\vvec_2</m>
-	</p></li>
-
-	<li><p> Because <m>|\lambda_2| \lt 1</m>, larger powers
-	<m>\lambda_2^n</m> are very close to zero.  </p></li>
-
-	<li><p> <m>L_{20} = 15127</m>.</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -1135,6 +1135,30 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p><m>A=\mattwo{\frac12}{\frac12}10</m></p></li>
+
+	<li><p> The eigenvalues are <m>\lambda_1=1</m> and
+	<m>\lambda_2=-\frac12</m> with associated eigenvectors
+	<m>\vvec_1=\twovec11</m> and <m>\vvec_2=\twovec{1}{-2}</m>.
+	</p></li>
+
+	<li><p> We have one eigenvalue <m>|\lambda_1| = 1</m>, which
+	means this system does not fall into any of our
+	cases. </p></li>
+
+	<li><p> <m>\xvec_0 = \frac23\vvec_1 +
+	\frac13\vvec_2</m> </p></li>
+
+	<li><p>
+	<m>\xvec_n=\frac23\vvec_1+
+	\frac13\left(-\frac12\right)^n\vvec_n</m> </p></li>
+
+	<li><p> <m>G_n</m>
+	stabilizes at <m>\frac23</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If <m>A=\mattwo{\frac12}{\frac12}10</m>, then we have
@@ -1165,31 +1189,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p><m>A=\mattwo{\frac12}{\frac12}10</m></p></li>
 
-	<li><p> The eigenvalues are <m>\lambda_1=1</m> and
-	<m>\lambda_2=-\frac12</m> with associated eigenvectors
-	<m>\vvec_1=\twovec11</m> and <m>\vvec_2=\twovec{1}{-2}</m>.
-	</p></li>
-
-	<li><p> We have one eigenvalue <m>|\lambda_1| = 1</m>, which
-	means this system does not fall into any of our
-	cases. </p></li>
-
-	<li><p> <m>\xvec_0 = \frac23\vvec_1 +
-	\frac13\vvec_2</m> </p></li>
-
-	<li><p> 
-	<m>\xvec_n=\frac23\vvec_1+
-	\frac13\left(-\frac12\right)^n\vvec_n</m> </p></li>
-
-	<li><p> <m>G_n</m>
-	stabilizes at <m>\frac23</m>. </p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -1243,6 +1243,38 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>A=
+	\left[\begin{array}{rrr}
+	0 \amp 0 \amp 8 \\
+	\frac 12 \amp 0 \amp 0 \\
+	0 \amp \frac 14 \amp 0 \\
+	\end{array}\right]</m>.
+	</p></li>
+
+	<li><p> We can use Sage to compute that
+	<m>A^3=I</m>. </p></li>
+
+	<li><p> Any
+	eigenvalue <m>\lambda</m> of <m>A</m> must satisfy
+	<m>\lambda^3=1</m>.  </p></li>
+
+	<li><p>
+	<m>\lambda_1=1</m> and <m>\lambda_{2,3} =
+	-\frac12\pm\frac{\sqrt3}{2}i</m>
+	</p></li>
+
+	<li><p>
+	  The trajectories lie on
+	circles about the line defined by <m>\threevec841</m>. </p></li>
+
+	<li><p> After every three years, the populations return to
+	their initial values. </p></li>
+
+	<li><p> <m>\xvec_0=\vvec_1 = \threevec841</m></p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have <m>\xvec_{k+1} = A\xvec_k</m> where <m>A =
@@ -1280,38 +1312,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>A=
-	\left[\begin{array}{rrr}
-	0 \amp 0 \amp 8 \\
-	\frac 12 \amp 0 \amp 0 \\
-	0 \amp \frac 14 \amp 0 \\
-	\end{array}\right]</m>.
-	</p></li>
-
-	<li><p> We can use Sage to compute that
-	<m>A^3=I</m>. </p></li>
-
-	<li><p> Any
-	eigenvalue <m>\lambda</m> of <m>A</m> must satisfy
-	<m>\lambda^3=1</m>.  </p></li>
-
-	<li><p> 
-	<m>\lambda_1=1</m> and <m>\lambda_{2,3} =
-	-\frac12\pm\frac{\sqrt3}{2}i</m>
-	</p></li>
-
-	<li><p>
-	  The trajectories lie on
-	circles about the line defined by <m>\threevec841</m>. </p></li>
-
-	<li><p> After every three years, the populations return to
-	their initial values. </p></li>
-
-	<li><p> <m>\xvec_0=\vvec_1 = \threevec841</m></p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises4-5.xml
+++ b/src/exercises/exercises4-5.xml
@@ -69,6 +69,23 @@
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> Any Markov chain will converge to
+	<m>\qvec=\twovec10</m>.</p></li>
+
+	<li><p> Any Markov chain will converge to
+	<m>\qvec=\twovec{\frac56}{\frac16}</m>.
+	</p></li>
+
+	<li><p> The steady-state vectors are those for
+	which <m>\qvec=\twovec{p}{1-p}</m> for some <m>p</m>
+	satisfying <m>0\leq p\leq 1</m>.  </p></li>
+
+	<li><p> Any Markov chain will converge to
+	<m>\qvec=\twovec{\frac23}{\frac13}</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The eigenvalues are <m>\lambda_1=1</m> and
@@ -95,23 +112,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> Any Markov chain will converge to
-	<m>\qvec=\twovec10</m>.</p></li>
-
-	<li><p> Any Markov chain will converge to
-	<m>\qvec=\twovec{\frac56}{\frac16}</m>.
-	</p></li>
-
-	<li><p> The steady-state vectors are those for
-	which <m>\qvec=\twovec{p}{1-p}</m> for some <m>p</m> 
-	satisfying <m>0\leq p\leq 1</m>.  </p></li>
-
-	<li><p> Any Markov chain will converge to 
-	<m>\qvec=\twovec{\frac23}{\frac13}</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -182,6 +182,30 @@ markov_chain(A, x0, 20)
       </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	<m>A=
+	\left[\begin{array}{rrr}
+	0.85 \amp 0.06 \amp 0.05 \\
+	0.07 \amp 0.86 \amp 0.07 \\
+	0.08 \amp 0.08 \amp 0.88 \\
+	\end{array}\right]
+	</m>.
+	</p></li>
+
+	<li><p> There is a unique
+	steady-state vector <m>\qvec</m> and any Markov chain
+	will converge to <m>\qvec</m>.</p></li>
+
+	<li><p> Any Markov chain we create will converge to
+	<m>\qvec=\threevec{0.267}{0.333}{0.400}</m>.  </p></li>
+
+	<li><p> Eventually, about <m>26.7</m>% of the population
+	will be rural, <m>33.3</m>% will be suburban, and
+	<m>40.0</m>% will be urban.</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The diagram tells us that
@@ -220,30 +244,6 @@ markov_chain(A, x0, 20)
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> 
-	<m>A=
-	\left[\begin{array}{rrr}
-	0.85 \amp 0.06 \amp 0.05 \\
-	0.07 \amp 0.86 \amp 0.07 \\
-	0.08 \amp 0.08 \amp 0.88 \\
-	\end{array}\right]
-	</m>.
-	</p></li>
-
-	<li><p> There is a unique
-	steady-state vector <m>\qvec</m> and any Markov chain
-	will converge to <m>\qvec</m>.</p></li>
-
-	<li><p> Any Markov chain we create will converge to
-	<m>\qvec=\threevec{0.267}{0.333}{0.400}</m>.  </p></li>
-
-	<li><p> Eventually, about <m>26.7</m>% of the population
-	will be rural, <m>33.3</m>% will be suburban, and
-	<m>40.0</m>% will be urban.</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -271,6 +271,15 @@ markov_chain(A, x0, 20)
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+	<li><p> False </p></li>
+	<li><p> True </p></li>
+	<li><p> False </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> True.  Every stochastic matrix has an eigenvalue
@@ -299,16 +308,7 @@ markov_chain(A, x0, 20)
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-	<li><p> False </p></li>
-	<li><p> True </p></li>
-	<li><p> False </p></li>
-      </ol></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -340,6 +340,23 @@ markov_chain(A, x0, 20)
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> The eigenvalues are <m>\lambda_1=1</m>,
+	<m>\lambda_2=0.8</m>, and <m>\lambda_3=0.4</m> with associated
+	eigenvectors <m>\vvec_1=\threevec100</m>,
+	<m>\vvec_2=\threevec{-2}11</m>, and
+	<m>\vvec_3=\threevec01{-1}</m>. </p></li>
+
+	<li><p> No
+	</p></li>
+
+	<li><p> <m>\qvec=\threevec100</m> </p></li>
+
+	<li><p> Any Markov chain will converge to
+	<m>\qvec</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The eigenvalues are <m>\lambda_1=1</m>,
@@ -363,25 +380,8 @@ markov_chain(A, x0, 20)
 	than <m>1</m>. </p></li>
       </ol></p>
     </solution>
-    
-    <answer>
-      <p><ol marker="a.">
-	<li><p> The eigenvalues are <m>\lambda_1=1</m>,
-	<m>\lambda_2=0.8</m>, and <m>\lambda_3=0.4</m> with associated
-	eigenvectors <m>\vvec_1=\threevec100</m>,
-	<m>\vvec_2=\threevec{-2}11</m>, and
-	<m>\vvec_3=\threevec01{-1}</m>. </p></li>
 
-	<li><p> No
-	</p></li>
 
-	<li><p> <m>\qvec=\threevec100</m> </p></li>
-
-	<li><p> Any Markov chain will converge to
-	<m>\qvec</m>. </p></li> 
-      </ol></p>
-    </answer>
-    
   </exercise>
 
   <!--
@@ -432,6 +432,19 @@ markov_chain(A, x0, 20)
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> It is not computationally feasible. </p></li>
+
+	<li><p> A Markov chain does not converge or it may converge to
+	a probability vector having some zero entries. </p></li>
+
+	<li><p> In both of these situations, the Google matrix is not
+	positive. </p></li>
+
+	<li><p> <m>G'</m> is guaranteed to be positive. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The modified Google matrix <m>G'</m> is huge, roughly 30
@@ -456,19 +469,6 @@ markov_chain(A, x0, 20)
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> It is not computationally feasible. </p></li>
-
-	<li><p> A Markov chain does not converge or it may converge to
-	a probability vector having some zero entries. </p></li>
-
-	<li><p> In both of these situations, the Google matrix is not
-	positive. </p></li>
-
-	<li><p> <m>G'</m> is guaranteed to be positive. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <p> In the next few exercises, we will consider the <m>1\times n</m>
@@ -496,6 +496,21 @@ markov_chain(A, x0, 20)
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>S\xvec=[1]</m>. </p></li>
+
+	<li><p> If <m>\xvec</m> is a
+	probability vector, <m>S\xvec=[1]</m>.
+	</p></li>
+
+	<li><p> The entries in <m>SA</m> are the
+	sums of the columns of <m>A</m>, which are all <m>1</m>.
+	</p></li>
+
+	<li><p> <m>S(A\xvec)=(SA)\xvec = S\xvec = [1]</m></p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Since the components of <m>\xvec</m> are nonnegative
@@ -524,21 +539,6 @@ markov_chain(A, x0, 20)
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>S\xvec=[1]</m>. </p></li>
-
-	<li><p> If <m>\xvec</m> is a
-	probability vector, <m>S\xvec=[1]</m>.
-	</p></li>
-
-	<li><p> The entries in <m>SA</m> are the
-	sums of the columns of <m>A</m>, which are all <m>1</m>.  
-	</p></li>
-
-	<li><p> <m>S(A\xvec)=(SA)\xvec = S\xvec = [1]</m></p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -559,6 +559,17 @@ markov_chain(A, x0, 20)
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>S(AB) = (SA)B = SB = S</m></p></li>
+
+	<li><p> This follows from the previous part.</p></li>
+
+	<li><p> A steady-state vector for <m>A</m> is a steady-state
+	vector for <m>A^2</m> but a steady-state vector for <m>A^2</m>
+	is not necessarily a steady-state vector for <m>A</m>.</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> If both <m>A</m> and <m>B</m> are stochastic, all the
@@ -591,18 +602,7 @@ markov_chain(A, x0, 20)
 	</p></li>
       </ol></p>
     </solution>
-    
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>S(AB) = (SA)B = SB = S</m></p></li>
 
-	<li><p> This follows from the previous part.</p></li>
-
-	<li><p> A steady-state vector for <m>A</m> is a steady-state
-	vector for <m>A^2</m> but a steady-state vector for <m>A^2</m>
-	is not necessarily a steady-state vector for <m>A</m>.</p></li>
-      </ol></p>
-    </answer>    
   </exercise>
 
   <exercise xml:id="exercise-stochastic-eigenvalue">
@@ -629,6 +629,27 @@ markov_chain(A, x0, 20)
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>S(A-I) =
+	\left[\begin{array}{rrrr}0\amp0\amp\cdots\amp 0
+	\end{array}\right]</m>
+	</p></li>
+
+	<li><p> <m>S\evec_1 = \begin{bmatrix}1\end{bmatrix}</m>.
+	</p></li>
+
+	<li><p> <m>S(A-I)\xvec = [0]</m> while <m>S\evec_1=[1]</m>.
+	</p></li>
+
+	<li><p> The span of the columns of <m>A-I</m> is not
+	<m>\real^n</m>.</p></li>
+
+	<li><p> The span of the columns of <m>A-I</m> is not
+	<m>\real^n</m>, we know that <m>A-I</m> is not
+	invertible. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Notice that both <m>A</m> and <m>I</m> are stochastic.
@@ -664,27 +685,6 @@ markov_chain(A, x0, 20)
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>S(A-I) =
-	\left[\begin{array}{rrrr}0\amp0\amp\cdots\amp 0 
-	\end{array}\right]</m>
-	</p></li>
-
-	<li><p> <m>S\evec_1 = \begin{bmatrix}1\end{bmatrix}</m>.
-	</p></li>
-	
-	<li><p> <m>S(A-I)\xvec = [0]</m> while <m>S\evec_1=[1]</m>.
-	</p></li> 
-
-	<li><p> The span of the columns of <m>A-I</m> is not
-	<m>\real^n</m>.</p></li> 
-
-	<li><p> The span of the columns of <m>A-I</m> is not
-	<m>\real^n</m>, we know that <m>A-I</m> is not
-	invertible. </p></li>  
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -765,6 +765,25 @@ modified_markov_chain(G, x0, 20)
       reasonable amount of steps.</p>
     </statement>
 
+    <answer>
+      <p> <ol marker="a.">
+	<li><p> If <m>\alpha = 0</m>, then <m>G'=H_n</m> and we see
+	that any Markov chain converges to the steady-state vector
+	<m>\qvec</m> in one term.
+	That is, <m>\xvec_1=\qvec</m>. </p></li>
+
+	<li><p> After six terms, we have <m>\xvec_6=\qvec</m> to
+	three digits. </p></li>
+
+	<li><p> With <m>\alpha = 0.5</m>, it is not until
+	<m>\xvec_{11}=\qvec</m> to three digits. With
+	<m>\alpha=0.75</m>, it is not until
+	<m>\xvec_{26}</m>. </p></li>
+
+	<li><p> With <m>\alpha=1</m>, we have <m>G'=G</m> so the
+	Markov chain will never converge. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p> Remember that the steady-state vector for <m>G'</m> is
       <m>\qvec=\left[\begin{array}{c}
@@ -791,25 +810,6 @@ modified_markov_chain(G, x0, 20)
 	Markov chain will never converge. </p></li>
       </ol></p>
     </solution>
-    <answer>
-      <p> <ol marker="a.">
-	<li><p> If <m>\alpha = 0</m>, then <m>G'=H_n</m> and we see
-	that any Markov chain converges to the steady-state vector
-	<m>\qvec</m> in one term. 
-	That is, <m>\xvec_1=\qvec</m>. </p></li>
-
-	<li><p> After six terms, we have <m>\xvec_6=\qvec</m> to
-	three digits. </p></li>
-
-	<li><p> With <m>\alpha = 0.5</m>, it is not until
-	<m>\xvec_{11}=\qvec</m> to three digits. With
-	<m>\alpha=0.75</m>, it is not until
-	<m>\xvec_{26}</m>. </p></li>
-
-	<li><p> With <m>\alpha=1</m>, we have <m>G'=G</m> so the
-	Markov chain will never converge. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -1008,6 +1008,36 @@ markov_chain(A, x0, 10)
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p>
+	The chances are <m>31.2</m>% that
+	we arrive at square <m>8</m> after four moves and
+	<m>98.4</m>% that we arrive after five moves.  We
+	are guaranteed to arrive after seven moves.
+	</p></li>
+
+	<li><p> We find that
+	<ol marker="1.">
+	  <li><p> We can first arrive at square <m>6</m> after three
+	  moves.  The chances of doing so are <m>12.5</m>%. </p></li>
+
+	  <li><p> After five moves, there is a <m>31.2</m>%
+	  chance that we have arrived at square <m>6</m>. </p></li>
+
+	  <li><p> The chances of being on square <m>1</m> after five
+	  moves is <m>15.6</m>%.  After seven moves, it is
+	  still <m>15.6</m>%.  After nine moves, however, it
+	  is <m>11.9</m>%. </p></li>
+
+	  <li><p> After 23 moves, there is a <m>90.2</m>%
+	  chance that we have arrived at square <m>6</m>. </p></li>
+
+	  <li><p> <m>\qvec=\evec_6</m> </p></li>
+	</ol>
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have the matrix
@@ -1098,36 +1128,6 @@ markov_chain(A, x0, 10)
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> 
-	The chances are <m>31.2</m>% that
-	we arrive at square <m>8</m> after four moves and
-	<m>98.4</m>% that we arrive after five moves.  We
-	are guaranteed to arrive after seven moves.
-	</p></li>
-
-	<li><p> We find that
-	<ol marker="1.">
-	  <li><p> We can first arrive at square <m>6</m> after three
-	  moves.  The chances of doing so are <m>12.5</m>%. </p></li>
-
-	  <li><p> After five moves, there is a <m>31.2</m>%
-	  chance that we have arrived at square <m>6</m>. </p></li>
-
-	  <li><p> The chances of being on square <m>1</m> after five
-	  moves is <m>15.6</m>%.  After seven moves, it is
-	  still <m>15.6</m>%.  After nine moves, however, it
-	  is <m>11.9</m>%. </p></li>
-
-	  <li><p> After 23 moves, there is a <m>90.2</m>%
-	  chance that we have arrived at square <m>6</m>. </p></li>
-
-	  <li><p> <m>\qvec=\evec_6</m> </p></li>
-	</ol>
-	</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 

--- a/src/exercises/exercises5-1.xml
+++ b/src/exercises/exercises5-1.xml
@@ -37,6 +37,12 @@
       is not much we can do to remedy this problem. </p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\xvec=\twovec20</m>. </p></li>
+	<li><p> <m>\xvec=\twovec11</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We find the solution <m>\xvec=\twovec20</m>. </p></li>
@@ -44,12 +50,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\xvec=\twovec20</m>. </p></li>
-	<li><p> <m>\xvec=\twovec11</m>. </p></li> 
-      </ol></p>
-    </answer>
 </exercise>
 
   <exercise>
@@ -73,6 +73,14 @@
       </sage>
     </statement>
 
+    <answer>
+      <p> <m>U=	\left[\begin{array}{rrr}
+	3 \amp 7 \amp 4 \\
+	0 \amp \frac53 \amp \frac23 \\
+	0 \amp 0 \amp -\frac15 \\
+	\end{array}\right]
+      </m></p>
+    </answer>
     <solution>
       <p> Using partial pivoting, we find
       <md>
@@ -107,15 +115,7 @@
       <c>LU</c> command. </p>  
     </solution>
 
-    <answer>
-      <p> <m>U=	\left[\begin{array}{rrr}
-	3 \amp 7 \amp 4 \\
-	0 \amp \frac53 \amp \frac23 \\
-	0 \amp 0 \amp -\frac15 \\
-	\end{array}\right]
-      </m></p>
-    </answer>
-	
+
   </exercise>
 
   <exercise>
@@ -160,6 +160,13 @@
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\xvec=\twovec{-2}3</m> </p></li>
+
+	<li><p> <m>\xvec=\threevec212</m> </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We solve <m>L\cvec=\twovec{-3}{0}</m> to find
@@ -172,13 +179,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\xvec=\twovec{-2}3</m> </p></li>
-
-	<li><p> <m>\xvec=\threevec212</m> </p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -200,6 +200,10 @@
       </sage>
     </statement>
 
+    <answer>
+      <p> <m>\xvec=\threevec2{-2}1</m>
+      </p>
+    </answer>
     <solution>
       <p>
 	We obtain the decomposition
@@ -233,10 +237,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p> <m>\xvec=\threevec2{-2}1</m>
-      </p>
-    </answer>
 
   </exercise>
 
@@ -276,6 +276,22 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\lambda=1</m> is an eigenvalue.  </p></li>
+
+	<li><p> <m>\left[\begin{array}{rrr} 1 \amp 0 \amp 0 \\
+	0 \amp 1 \amp 0 \\
+	0 \amp 0 \amp 1 \\
+	\end{array}\right]</m>.  </p></li>
+
+	<li><p> The computation tells us that <m>A-I</m> is
+	invertible, which is not true.  </p></li>
+
+	<li><p> The approximate arithmetic creates a nonexistent third
+	pivot position. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Since <m>A</m> is a positive stochastic matrix, we
@@ -319,22 +335,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\lambda=1</m> is an eigenvalue.  </p></li>
-
-	<li><p> <m>\left[\begin{array}{rrr} 1 \amp 0 \amp 0 \\
-	0 \amp 1 \amp 0 \\
-	0 \amp 0 \amp 1 \\
-	\end{array}\right]</m>.  </p></li>
-
-	<li><p> The computation tells us that <m>A-I</m> is
-	invertible, which is not true.  </p></li>
-
-	<li><p> The approximate arithmetic creates a nonexistent third
-	pivot position. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -373,6 +373,18 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p>
+	<m>
+	  A^{-1} = U^{-1}L^{-1}P =
+	  \left[\begin{array}{rrr}
+	  -\frac{15}{13} \amp \frac{17}{13} \amp -\frac{8}{13} \\
+	  \frac{11}{13} \amp -\frac{9}{13} \amp \frac{5}{13} \\
+	  -\frac{14}{13} \amp \frac{15}{13} \amp -\frac{4}{13}
+	  \end{array}\right]
+	  </m>.
+      </p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Notice that a row interchange is undone by the same
@@ -419,19 +431,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p>
-	<m>
-	  A^{-1} = U^{-1}L^{-1}P =
-	  \left[\begin{array}{rrr}
-	  -\frac{15}{13} \amp \frac{17}{13} \amp -\frac{8}{13} \\
-	  \frac{11}{13} \amp -\frac{9}{13} \amp \frac{5}{13} \\
-	  -\frac{14}{13} \amp \frac{15}{13} \amp -\frac{4}{13}
-	  \end{array}\right]
-	  </m>.
-      </p>
-    </answer>
-	  
+
   </exercise>
 
   <exercise>
@@ -455,6 +455,30 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> We find
+	<md>
+	  L = \left[\begin{array}{rrrr}
+	  1 \amp 0 \amp 0 \amp 0 \\
+	  1 \amp 1 \amp 0 \amp 0 \\
+	  1 \amp 1 \amp 1 \amp 0 \\
+	  1 \amp 1 \amp 1 \amp 1 \\
+	  \end{array}\right],
+	  U =
+	  \left[\begin{array}{rrrr}
+	  a \amp a \amp a \amp a \\
+	  0 \amp b-a \amp b-a \amp b-a \\
+	  0 \amp 0 \amp c-b \amp c-b \\
+	  0 \amp 0 \amp 0 \amp d-c \\
+	  \end{array}\right]\text{.}
+	</md>
+	</p></li>
+
+	<li><p> <m>a\neq0</m>, <m>b\neq
+	a</m>, <m>c\neq b</m>, and <m>d\neq c</m>.</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We begin with <m>E_1A=A_1</m> where
@@ -533,30 +557,6 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> We find
-	<md>
-	  L = \left[\begin{array}{rrrr}
-	  1 \amp 0 \amp 0 \amp 0 \\
-	  1 \amp 1 \amp 0 \amp 0 \\
-	  1 \amp 1 \amp 1 \amp 0 \\
-	  1 \amp 1 \amp 1 \amp 1 \\
-	  \end{array}\right],
-	  U =
-	  \left[\begin{array}{rrrr}
-	  a \amp a \amp a \amp a \\
-	  0 \amp b-a \amp b-a \amp b-a \\
-	  0 \amp 0 \amp c-b \amp c-b \\
-	  0 \amp 0 \amp 0 \amp d-c \\
-	  \end{array}\right]\text{.}
-	</md>
-	</p></li>
-
-	<li><p> <m>a\neq0</m>, <m>b\neq
-	a</m>, <m>c\neq b</m>, and <m>d\neq c</m>.</p></li>
-      </ol></p>
-    </answer>
 
   </exercise>
 
@@ -591,6 +591,29 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>A= LU =
+	  \left[\begin{array}{rrr}
+	  1 \amp 0 \amp 0 \\
+	  -2 \amp 1 \amp 0 \\
+	  0 \amp 2 \amp 1 \\
+	  \end{array}\right]
+	  \left[\begin{array}{rrr}
+	  3 \amp 1 \amp 1 \\
+	  0 \amp -2 \amp -1 \\
+	  0 \amp 0 \amp -1 \\
+	  \end{array}\right]</m>.
+	</p></li>
+
+	<li><p> <m>\det A = \det L \det U = \det U</m>. </p></li>
+
+	<li><p> <m>\det A = 6</m> </p></li>
+
+	<li><p> <m>\det A = \det P \det L \det U = \pm \det
+	U</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We have
@@ -643,31 +666,8 @@
 	pivots. </p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>A= LU = 
-	  \left[\begin{array}{rrr}
-	  1 \amp 0 \amp 0 \\
-	  -2 \amp 1 \amp 0 \\
-	  0 \amp 2 \amp 1 \\
-	  \end{array}\right]
-	  \left[\begin{array}{rrr}
-	  3 \amp 1 \amp 1 \\
-	  0 \amp -2 \amp -1 \\
-	  0 \amp 0 \amp -1 \\
-	  \end{array}\right]</m>.
-	</p></li>
 
-	<li><p> <m>\det A = \det L \det U = \det U</m>. </p></li>
 
-	<li><p> <m>\det A = 6</m> </p></li>
-
-	<li><p> <m>\det A = \det P \det L \det U = \pm \det
-	U</m>. </p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -693,6 +693,19 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> When working with a large matrix, the errors from
+	individual calculations may accumulate. </p></li>
+
+	<li><p> We can solve <m>A\xvec=\bvec</m> for a couple of
+	different <m>\bvec</m> without performing Gaussian elimination
+	again. </p></li>
+
+	<li><p> <m>A</m> is invertible if and only if <m>U</m>
+	is.</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> Since a typical computer has 15 or more decimal places
@@ -714,20 +727,7 @@
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> When working with a large matrix, the errors from
-	individual calculations may accumulate. </p></li>
 
-	<li><p> We can solve <m>A\xvec=\bvec</m> for a couple of
-	different <m>\bvec</m> without performing Gaussian elimination
-	again. </p></li>
-
-	<li><p> <m>A</m> is invertible if and only if <m>U</m>
-	is.</p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -754,6 +754,38 @@
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> We see that
+	<md>
+	  \begin{array}{c}
+	  P=\left[\begin{array}{rrrr}
+	  1 \amp 0 \amp 0 \amp 0 \\
+	  0 \amp 1 \amp 0 \amp 0 \\
+	  0 \amp 0 \amp 1 \amp 0 \\
+	  0 \amp 0 \amp 0 \amp 1 \\
+	  \end{array}\right],
+	  L=\left[\begin{array}{rrrr}
+	  1 \amp 0 \amp 0 \amp 0 \\
+	  -1 \amp 1 \amp 0 \amp 0 \\
+	  0 \amp -1 \amp 1 \amp 0 \\
+	  0 \amp 0 \amp 1 \amp 1 \\
+	  \end{array}\right], \\
+	  U=\left[\begin{array}{rrrr}
+	  -1 \amp 1 \amp 0 \amp 0 \\
+	  0 \amp -1 \amp 1 \amp 0 \\
+	  0 \amp 0 \amp -1 \amp 1 \\
+	  0 \amp 0 \amp 0 \amp 0 \\
+	  \end{array}\right]\text{.}
+	  \end{array}
+	</md>
+	</p></li>
+
+	<li><p> <m>\fourvec1111</m>. </p></li>
+
+	<li><p> No </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We see that
@@ -793,40 +825,8 @@
 	<m>\col(L)=\real^4</m>. </p></li>
       </ol></p>
     </solution>
-	  
-    <answer>
-      <p><ol marker="a.">
-	<li><p> We see that
-	<md>
-	  \begin{array}{c}
-	  P=\left[\begin{array}{rrrr}
-	  1 \amp 0 \amp 0 \amp 0 \\
-	  0 \amp 1 \amp 0 \amp 0 \\
-	  0 \amp 0 \amp 1 \amp 0 \\
-	  0 \amp 0 \amp 0 \amp 1 \\
-	  \end{array}\right],
-	  L=\left[\begin{array}{rrrr}
-	  1 \amp 0 \amp 0 \amp 0 \\
-	  -1 \amp 1 \amp 0 \amp 0 \\
-	  0 \amp -1 \amp 1 \amp 0 \\
-	  0 \amp 0 \amp 1 \amp 1 \\
-	  \end{array}\right], \\
-	  U=\left[\begin{array}{rrrr}
-	  -1 \amp 1 \amp 0 \amp 0 \\
-	  0 \amp -1 \amp 1 \amp 0 \\
-	  0 \amp 0 \amp -1 \amp 1 \\
-	  0 \amp 0 \amp 0 \amp 0 \\
-	  \end{array}\right]\text{.}
-	  \end{array}
-	</md>
-	</p></li>
 
-	<li><p> <m>\fourvec1111</m>. </p></li>
 
-	<li><p> No </p></li>
-      </ol></p>
-    </answer>
-	  
   </exercise>
 
 	

--- a/src/exercises/exercises5-2.xml
+++ b/src/exercises/exercises5-2.xml
@@ -38,6 +38,15 @@ def inverse_power(A, x, N):
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>-\frac13</m>, <m>-5</m>, <m>1</m>, and
+	<m>\frac14</m>. </p></li>
+
+	<li><p> <m>-4</m>, <m>6.8</m>,
+	<m>8</m>, and <m>12</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The eigenvalues of <m>A^{-1}</m> are the reciprocals
@@ -52,15 +61,6 @@ def inverse_power(A, x, N):
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>-\frac13</m>, <m>-5</m>, <m>1</m>, and
-	<m>\frac14</m>. </p></li>
-
-	<li><p> <m>-4</m>, <m>6.8</m>,
-	<m>8</m>, and <m>12</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -97,6 +97,17 @@ def inverse_power(A, x, N):
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> <m>\lambda = -6</m> and <m>2</m>. </p></li>
+
+	<li><p> <m>\lambda=1.024</m> and <m>-0.224</m>. </p></li>
+
+	<li><p> <m>\lambda = -14.014</m>,
+	<m>-1.530</m>, <m>11.226</m>, and
+	<m>4.618</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> The power method tells us that the dominant eigenvalue
@@ -131,18 +142,7 @@ def inverse_power(A, x, N):
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> <m>\lambda = -6</m> and <m>2</m>. </p></li>
 
-	<li><p> <m>\lambda=1.024</m> and <m>-0.224</m>. </p></li>
-
-	<li><p> <m>\lambda = -14.014</m>,
-	<m>-1.530</m>, <m>11.226</m>, and 
-	<m>4.618</m>. </p></li>
-      </ol></p>
-    </answer>
-	
   </exercise>
 
   <exercise>
@@ -169,6 +169,11 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       </sage>
     </statement>
 
+    <answer>
+      <p> <m>\lambda=9.449</m>,
+      <m>-2.134</m>,
+      <m>-4.399</m>, <m>7.100</m>, and <m>5.974</m>. </p>
+    </answer>
     <solution>
       <p> The power method shows us that <m>\lambda_1=9.449</m> is the
       dominant eigenvalue.  The inverse power method tells us that
@@ -177,12 +182,7 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       <m>-4.399</m>, <m>7.100</m>, and <m>5.974</m>. </p>
     </solution>
 
-    <answer>
-      <p> <m>\lambda=9.449</m>,
-      <m>-2.134</m>,
-      <m>-4.399</m>, <m>7.100</m>, and <m>5.974</m>. </p>
-    </answer>
-    
+
   </exercise>
 
   <exercise>
@@ -212,6 +212,16 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
 
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> The methods do not converge. </p></li>
+
+	<li><p> There is not a unique dominant eigenvalue. </p></li>
+
+	<li><p> Try finding an eigenvalue closest to, say,
+	<m>5</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We see that neither the power method nor the inverse
@@ -230,16 +240,6 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> The methods do not converge. </p></li>
-
-	<li><p> There is not a unique dominant eigenvalue. </p></li>
-
-	<li><p> Try finding an eigenvalue closest to, say,
-	<m>5</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise xml:id="exercise-power-method">
@@ -266,6 +266,24 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
     </statement>
 
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> We see that the vectors <m>\overline{\xvec}_k</m> do
+	not converge and the multipliers <m>m_k</m> converge to the
+	wrong value. </p></li>
+
+	<li><p> The multipliers are obtained
+	from the first component, then the second component, then the
+	first, and so on.
+	</p></li>
+
+	<li><p> Choose one of the components, say, the first one and
+	consider the ratio between that component of
+	<m>A\overline{\xvec}_k</m> and <m>\overline{\xvec}_k</m>
+	in place of the multiplier <m>m_k</m>.
+	</p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> We see that the vectors <m>\overline{\xvec}_k</m> do
@@ -291,24 +309,6 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> We see that the vectors <m>\overline{\xvec}_k</m> do
-	not converge and the multipliers <m>m_k</m> converge to the
-	wrong value. </p></li>
-
-	<li><p> The multipliers are obtained
-	from the first component, then the second component, then the
-	first, and so on.
-	</p></li>
-
-	<li><p> Choose one of the components, say, the first one and
-	consider the ratio between that component of
-	<m>A\overline{\xvec}_k</m> and <m>\overline{\xvec}_k</m>
-	in place of the multiplier <m>m_k</m>.  
-	</p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -322,6 +322,10 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       </p>
     </statement>
 
+    <answer>
+      <p> We will need more steps when finding the dominant eigenvalue
+      of <m>A</m>. </p>
+    </answer>
     <solution>
       <p> For both matrices, <m>\lambda_1=4</m> is the dominant
       eigenvalue and <m>\lambda_2</m> is the eigenvalue closest to
@@ -336,10 +340,6 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       eigenvalue of <m>A</m>.</p>
     </solution>
 
-    <answer>
-      <p> We will need more steps when finding the dominant eigenvalue
-      of <m>A</m>. </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -354,16 +354,16 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       the matrix <m>A</m> in this case?</p>
     </statement>
 
+    <answer>
+      <p> <m>\lambda=3</m> is the dominant eigenvalue with a
+      multiplicity greater than one. </p>
+    </answer>
     <solution>
       <p> The dominant eigenvector is <m>\lambda=3</m> but it has a
       multiplicity greater than one and the associated eigenspace has
       <m>\dim E_3 \gt 1</m>. </p>
     </solution>
 
-    <answer>
-      <p> <m>\lambda=3</m> is the dominant eigenvalue with a
-      multiplicity greater than one. </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -376,6 +376,9 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
 	</p>
     </statement>
 
+    <answer>
+      <p> The vectors <m>\overline{\xvec}_k</m> will not converge. </p>
+    </answer>
     <solution>
       <p> The power method relies on the fact that the vectors
       <m>\overline{\xvec}_k</m> attempt to line up in the direction of
@@ -385,9 +388,6 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       converge. </p>
     </solution>
 
-    <answer>
-      <p> The vectors <m>\overline{\xvec}_k</m> will not converge. </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -415,6 +415,18 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       </ol></p>
     </statement>
 
+    <answer>
+      <p><ol marker="a.">
+	<li><p> There is a single eigenvalue <m>\lambda=1</m> having
+	multiplicity two with its associated eigenspace <m>E_1</m>
+	being one-dimensional with basis vector <m>\vvec=\twovec10</m>.
+	</p></li>
+
+	<li><p> Applying either the power or inverse power method will
+	find the eigenvalue <m>\lambda=1</m> and a scalar multiple of
+	<m>\vvec</m>. </p></li>
+      </ol></p>
+    </answer>
     <solution>
       <p><ol marker="a.">
 	<li><p> There is a single eigenvalue <m>\lambda=1</m> having
@@ -428,18 +440,6 @@ A = matrix(5,5, [-14.6,  9.0, -14.1, 5.8,  13.0,
       </ol></p>
     </solution>
 
-    <answer>
-      <p><ol marker="a.">
-	<li><p> There is a single eigenvalue <m>\lambda=1</m> having
-	multiplicity two with its associated eigenspace <m>E_1</m>
-	being one-dimensional with basis vector <m>\vvec=\twovec10</m>.
-	</p></li>
-
-	<li><p> Applying either the power or inverse power method will
-	find the eigenvalue <m>\lambda=1</m> and a scalar multiple of
-	<m>\vvec</m>. </p></li>
-      </ol></p>
-    </answer>
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises6-1.xml
+++ b/src/exercises/exercises6-1.xml
@@ -29,6 +29,25 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\vvec\cdot\vvec=17</m>, <m>\wvec\cdot\wvec
+	      = 27</m>, <m>\len{\vvec} = \sqrt{17}</m>, and
+	      <m>\len{\wvec} = 3\sqrt{3}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\vvec\cdot\wvec=12</m> and <m>\theta
+	      = 55.9^\circ</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -49,25 +68,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\vvec\cdot\vvec=17</m>, <m>\wvec\cdot\wvec
-	      = 27</m>, <m>\len{\vvec} = \sqrt{17}</m>, and
-	      <m>\len{\wvec} = 3\sqrt{3}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\vvec\cdot\wvec=12</m> and <m>\theta
-	      = 55.9^\circ</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
 
   </exercise>
 
@@ -125,6 +125,45 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\uvec\cdot\uvec=9</m>,
+	      <m>\uvec\cdot\vvec=1</m>, and
+	      <m>\uvec\cdot\wvec=-6</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m>3</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>-5</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>-15</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>\threevec{1/3}{-2/3}{2/3}</m>
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -166,47 +205,8 @@
       </p>
     </solution>
 		      
-      
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\uvec\cdot\uvec=9</m>,
-	      <m>\uvec\cdot\vvec=1</m>, and
-	      <m>\uvec\cdot\wvec=-6</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    <m>3</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>-5</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>-15</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>\threevec{1/3}{-2/3}{2/3}</m>
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-      
+
+
   </exercise>
       
 
@@ -242,6 +242,28 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>2</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\theta
+	      = 26.6^\circ</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>t=-2</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -266,28 +288,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>2</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\theta
-	      = 26.6^\circ</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>t=-2</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -328,6 +328,33 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\vvec\cdot\vvec =
+	      9\wvec\cdot\wvec</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\len{\vvec} = 3\len{\wvec}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\len{\vvec} = |s|\len{\wvec}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>s=1/\sqrt{17}</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -358,34 +385,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\vvec\cdot\vvec = 
-	      9\wvec\cdot\wvec</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\len{\vvec} = 3\len{\wvec}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\len{\vvec} = |s|\len{\wvec}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>s=1/\sqrt{17}</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -401,6 +401,17 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	Use the relationship <m>\len{\uvec}^2 = \uvec\cdot\uvec</m>.
+      </p>
+      <image width="50%">
+        <prefigure xmlns="https://prefigure.org"
+                   label="pf-parallelogram-law-ans">
+          <xi:include href="prefigure/parallelogram-law.xml"/>
+        </prefigure>
+      </image>
+    </answer>
     <solution>
       <p>
 	<md>
@@ -428,18 +439,7 @@
         </prefigure>
       </image>
     </solution>
-    <answer>
-      <p>
-	Use the relationship <m>\len{\uvec}^2 = \uvec\cdot\uvec</m>.
-      </p>
-      <image width="50%">
-        <prefigure xmlns="https://prefigure.org"
-                   label="pf-parallelogram-law-ans">
-          <xi:include href="prefigure/parallelogram-law.xml"/>
-        </prefigure>
-      </image>
-    </answer>
-	  
+
   </exercise>
 
   <exercise>
@@ -485,6 +485,40 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>2x + 4z = 0</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		<mrow>
+		  2x + 4z {}={} 0
+		</mrow>
+		<mrow>
+		  -x+2y-4z {}={} 0
+		</mrow>
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xvec = x_3\threevec{-2}{1}1</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xvec = x_2\threevec{0}{1}{0} +
+	      x_3\threevec{-2}01</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -520,41 +554,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>2x + 4z = 0</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		<mrow>
-		  2x + 4z {}={} 0 
-		</mrow>
-		<mrow>
-		  -x+2y-4z {}={} 0
-		</mrow>
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xvec = x_3\threevec{-2}{1}1</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xvec = x_2\threevec{0}{1}{0} +
-	      x_3\threevec{-2}01</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	  
+
   </exercise>
 
   <exercise>
@@ -581,6 +581,21 @@
 	      
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p> Yes
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\vvec=\zerovec</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -598,21 +613,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p> Yes
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\vvec=\zerovec</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -666,6 +666,36 @@
 		
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Since <m>\vvec_1</m>, <m>\vvec_2</m>, and <m>\vvec_3</m>
+	      form a basis for <m>\real^3</m>, any vector in
+	      <m>\real^3</m> can be written as a linear combination of
+	      them.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Apply the distributive property.
+	    </p>
+	    <p>
+	      <m>c_2 =
+	      \frac{\vvec\cdot\vvec_2}{\vvec_2\cdot\vvec_2}</m> and
+	      <m>c_3 =
+	      \frac{\vvec\cdot\vvec_3}{\vvec_3\cdot\vvec_3}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\vvec = 2\vvec_1 - \vvec_2 + 2\vvec_3</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -703,36 +733,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Since <m>\vvec_1</m>, <m>\vvec_2</m>, and <m>\vvec_3</m>
-	      form a basis for <m>\real^3</m>, any vector in
-	      <m>\real^3</m> can be written as a linear combination of
-	      them.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Apply the distributive property.
-	    </p>
-	    <p>
-	      <m>c_2 =
-	      \frac{\vvec\cdot\vvec_2}{\vvec_2\cdot\vvec_2}</m> and
-	      <m>c_3 =
-	      \frac{\vvec\cdot\vvec_3}{\vvec_3\cdot\vvec_3}</m> 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\vvec = 2\vvec_1 - \vvec_2 + 2\vvec_3</m> 
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 	
 
@@ -760,6 +760,24 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      If <m>\vvec_3 = c_1\vvec_1 + c_2\vvec_2</m>, then
+	      <m>c_1=0</m> and <m>c_2=0</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      None of the vectors is a linear
+	      combination of the others.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -784,24 +802,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      If <m>\vvec_3 = c_1\vvec_1 + c_2\vvec_2</m>, then
-	      <m>c_1=0</m> and <m>c_2=0</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      None of the vectors is a linear
-	      combination of the others.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -842,6 +842,27 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>q(\xvec) = 13</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>q(\xvec) = x^2 + 4xy + y^2</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>q(\vvec) = \lambda</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -864,27 +885,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>q(\xvec) = 13</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>q(\xvec) = x^2 + 4xy + y^2</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>q(\vvec) = \lambda</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -976,6 +976,43 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>y=3-x/2</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xvec-\pvec</m> is orthogonal to <m>\nvec</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>0</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Apply the distributive property
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>x+2y = 6</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\nvec=\twovec{A}{B}</m> is
+	      perpendicular to the line.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1022,44 +1059,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>y=3-x/2</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xvec-\pvec</m> is orthogonal to <m>\nvec</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>0</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Apply the distributive property
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>x+2y = 6</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\nvec=\twovec{A}{B}</m> is
-	      perpendicular to the line.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-		
+
   </exercise>
       
 </exercises>

--- a/src/exercises/exercises6-2.xml
+++ b/src/exercises/exercises6-2.xml
@@ -32,6 +32,28 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\dim W = 2</m> and <m>\dim W^\perp = 2</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\vvec_1 = \fourvec{-2}{-3}10</m> and
+	      <m>\vvec_2=\fourvec{-1}101</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Use the dot product.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -55,29 +77,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\dim W = 2</m> and <m>\dim W^\perp = 2</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\vvec_1 = \fourvec{-2}{-3}10</m> and
-	      <m>\vvec_2=\fourvec{-1}101</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Use the dot product.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -104,6 +104,24 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\rank(A) = 2</m> and a basis for <m>\col(A)</m> is
+	      <m>\threevec{-1}12</m> and <m>\threevec{-2}31</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\dim\col(A)^\perp = 1</m> with basis
+	      <m>\threevec531</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -132,24 +150,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\rank(A) = 2</m> and a basis for <m>\col(A)</m> is
-	      <m>\threevec{-1}12</m> and <m>\threevec{-2}31</m> 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\dim\col(A)^\perp = 1</m> with basis
-	      <m>\threevec531</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -189,6 +189,33 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\dim W = 3</m>, <m>\dim W^\perp = 1</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\fourvec3100</m>,
+	      <m>\fourvec{-5}010</m>, and <m>\fourvec2001</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\fourvec1{-3}5{-2}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\fourvec ABCD</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -220,34 +247,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\dim W = 3</m>, <m>\dim W^\perp = 1</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\fourvec3100</m>,
-	      <m>\fourvec{-5}010</m>, and <m>\fourvec2001</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\fourvec1{-3}5{-2}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\fourvec ABCD</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	     
+
   </exercise>
 
   <exercise>
@@ -302,6 +302,37 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -337,38 +368,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -400,32 +400,6 @@
 	</ol>
       </p>
     </statement>
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>A^T(A^T)^{-1}B^{-1} = B^{-1}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A^TA + B^TA + A^TB + B^TB</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>(A+B)A^T = AA^T+BA^T</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A^T+2I</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
     <answer>
       <p>
 	<ol marker="a.">
@@ -452,6 +426,32 @@
 	</ol>
       </p>
     </answer>
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>A^T(A^T)^{-1}B^{-1} = B^{-1}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A^TA + B^TA + A^TB + B^TB</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>(A+B)A^T = AA^T+BA^T</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A^T+2I</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
   </exercise>
 
   <exercise>
@@ -496,6 +496,43 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      They must have the same number of rows and columns.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    Yes
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    No
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    No
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    Yes
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -538,44 +575,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      They must have the same number of rows and columns.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    Yes
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    No
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    No
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    Yes
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -608,6 +608,27 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Use properties of the matrix transpose.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Because they have the same characteristic polynomial.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A^T = (P^T)^{-1} D P^T</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -634,28 +655,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Use properties of the matrix transpose.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Because they have the same characteristic polynomial.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A^T = (P^T)^{-1} D P^T</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-    
+
   </exercise>
 
   <exercise>
@@ -692,6 +692,23 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\len{\vvec+\wvec}^2
+	      = \vvec\cdot\vvec+\wvec\cdot\wvec</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Because <m>\xvec</m> and <m>\yvec</m> are orthogonal.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -710,23 +727,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\len{\vvec+\wvec}^2 
-	      = \vvec\cdot\vvec+\wvec\cdot\wvec</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Because <m>\xvec</m> and <m>\yvec</m> are orthogonal.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -780,6 +780,29 @@
       </p>
 	      
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Use properties of the transpose.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Compute the dot product of <m>\vvec_1</m> and
+	      <m>\vvec_2</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      It follows that
+	      <m>(\lambda_1-\lambda_2)\vvec_1\cdot\vvec_2 = 0</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -816,30 +839,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Use properties of the transpose.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Compute the dot product of <m>\vvec_1</m> and
-	      <m>\vvec_2</m>. 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      It follows that
-	      <m>(\lambda_1-\lambda_2)\vvec_1\cdot\vvec_2 = 0</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -877,6 +877,30 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>p=15</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\row(A)^\perp = \
+	      \nul(A)</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      A basis for <m>\row(A)</m> are the
+	      three rows of <m>A</m>.  A basis for <m>\row(A)^\perp =
+	      \nul(A)</m> is <m>\fourvec{-2}100</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -903,30 +927,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>p=15</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\row(A)^\perp = \
-	      \nul(A)</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      A basis for <m>\row(A)</m> are the
-	      three rows of <m>A</m>.  A basis for <m>\row(A)^\perp =
-	      \nul(A)</m> is <m>\fourvec{-2}100</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
 
   </exercise>
 

--- a/src/exercises/exercises6-3.xml
+++ b/src/exercises/exercises6-3.xml
@@ -48,6 +48,46 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\wvec_1\cdot\wvec_2=0</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bhat =
+	      \threevec{1/2}1{1/2}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec_1=\frac{1}{\len{\wvec_1}}\wvec_1 =
+	      \threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}</m>
+	      and
+	      <m>\uvec_2=\frac{1}{\len{\wvec_2}}\wvec_2 =
+	      \threevec{1/\sqrt{6}}{-2/\sqrt{6}}{1/\sqrt{6}}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>P=\begin{bmatrix}
+	      1/2 \amp 0 \amp 1/2 \\
+	      0 \amp 1 \amp 0 \\
+	      1/2 \amp 0 \amp 1/2
+	      \end{bmatrix}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\rank(P) = 2</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -90,48 +130,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\wvec_1\cdot\wvec_2=0</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bhat =
-	      \threevec{1/2}1{1/2}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec_1=\frac{1}{\len{\wvec_1}}\wvec_1 =
-	      \threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}</m>
-	      and
-	      <m>\uvec_2=\frac{1}{\len{\wvec_2}}\wvec_2 =
-	      \threevec{1/\sqrt{6}}{-2/\sqrt{6}}{1/\sqrt{6}}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>P=\begin{bmatrix}
-	      1/2 \amp 0 \amp 1/2 \\
-	      0 \amp 1 \amp 0 \\
-	      1/2 \amp 0 \amp 1/2
-	      \end{bmatrix}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\rank(P) = 2</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 
   <exercise>
@@ -186,6 +186,51 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\wvec_1\cdot\wvec_1=0</m>,
+	      <m>\wvec_1\cdot\wvec_3=0</m>, and
+	      <m>\wvec_2\cdot\wvec_3=0</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A^TA = \begin{bmatrix}
+	      3 \amp 0 \amp 0 \\
+	      0 \amp 2 \amp 0 \\
+	      0 \amp 0 \amp 6
+	      \end{bmatrix}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bvec=-2\wvec_1+3\wvec_2+2\wvec_3</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		\uvec_1=\threevec{1/\sqrt{3}}{1/\sqrt{3}}
+		{1/\sqrt{3}},\hspace{24pt}
+		\uvec_2=\threevec{-1/\sqrt{2}}0{1/\sqrt{2}},
+		\hspace{24pt}
+		\uvec_3=\threevec{1/\sqrt{6}}{-2/\sqrt{6}}
+		{1/\sqrt{6}},\hspace{24pt}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>QQ^T=I</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -248,51 +293,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\wvec_1\cdot\wvec_1=0</m>, 
-	      <m>\wvec_1\cdot\wvec_3=0</m>, and
-	      <m>\wvec_2\cdot\wvec_3=0</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A^TA = \begin{bmatrix}
-	      3 \amp 0 \amp 0 \\
-	      0 \amp 2 \amp 0 \\
-	      0 \amp 0 \amp 6
-	      \end{bmatrix}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bvec=-2\wvec_1+3\wvec_2+2\wvec_3</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		\uvec_1=\threevec{1/\sqrt{3}}{1/\sqrt{3}}
-		{1/\sqrt{3}},\hspace{24pt}
-		\uvec_2=\threevec{-1/\sqrt{2}}0{1/\sqrt{2}},
-		\hspace{24pt}
-		\uvec_3=\threevec{1/\sqrt{6}}{-2/\sqrt{6}}
-		{1/\sqrt{6}},\hspace{24pt}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>QQ^T=I</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -330,6 +330,30 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\bhat = \fourvec{-1}{-2}13</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bvec^\perp = \fourvec{3}{1}{-7}4</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      A basis for <m>W^\perp</m> is
+	      <m>\vvec_1=\fourvec{-1}110</m> and
+	      <m>\vvec_2=\fourvec{-1}201</m>.  We then have
+	      <m>\bvec^\perp = -7\vvec_1 + 4\vvec_2</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -357,30 +381,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\bhat = \fourvec{-1}{-2}13</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bvec^\perp = \fourvec{3}{1}{-7}4</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      A basis for <m>W^\perp</m> is
-	      <m>\vvec_1=\fourvec{-1}110</m> and
-	      <m>\vvec_2=\fourvec{-1}201</m>.  We then have
-	      <m>\bvec^\perp = -7\vvec_1 + 4\vvec_2</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -417,6 +417,27 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\bhat_1 = \fourvec{-1}{-1}00</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bhat_2 = \fourvec{-1}{-1}22</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bhat_2</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -444,27 +465,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\bhat_1 = \fourvec{-1}{-1}00</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bhat_2 = \fourvec{-1}{-1}22</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bhat_2</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -498,6 +498,38 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <md>
+		\threevec{4/9}{-2/9}{4/9},\hspace{24pt}
+		\threevec{-2/9}{1/9}{4/9},\hspace{24pt}
+		\threevec{4/9}{-2/9}{4/9}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>P=\begin{bmatrix}
+	      4/9 \amp -2/9 \amp 4/9\\
+	      -2/9 \amp 1/9 \amp -2/9\\
+	      4/9 \amp -2/9 \amp 4/9\\
+	      \end{bmatrix}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The columns of <m>P</m> are
+	      the results of projecting the standard basis vectors
+	      onto <m>L</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -534,38 +566,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <md>
-		\threevec{4/9}{-2/9}{4/9},\hspace{24pt}
-		\threevec{-2/9}{1/9}{4/9},\hspace{24pt}
-		\threevec{4/9}{-2/9}{4/9}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>P=\begin{bmatrix}
-	      4/9 \amp -2/9 \amp 4/9\\
-	      -2/9 \amp 1/9 \amp -2/9\\
-	      4/9 \amp -2/9 \amp 4/9\\
-	      \end{bmatrix}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The columns of <m>P</m> are
-	      the results of projecting the standard basis vectors
-	      onto <m>L</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
 
   </exercise>
 
@@ -605,6 +605,27 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\threevec{-3}21</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\yvec = \threevec6{-4}{-2}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\zvec = \threevec0{-2}4 = 2\vvec_1-\vvec_2</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -630,28 +651,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\threevec{-3}21</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\yvec = \threevec6{-4}{-2}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\zvec = \threevec0{-2}4 = 2\vvec_1-\vvec_2</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
   </exercise>
 
   <exercise>
@@ -696,6 +696,37 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
       <ol marker="a.">
@@ -735,37 +766,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -804,31 +804,6 @@
       </p>
     </statement>
 
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>Q\xvec\cdot(Q\yvec) = (Q\xvec)^T\cdot(Q\yvec) =
-	      \xvec^TQ^TQ\yvec = \xvec^T\yvec=\xvec\cdot\yvec</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\len{Q\xvec}^2 = (Q\xvec)\cdot(Q\xvec) =
-	      \xvec\cdot\xvec = \len{\xvec}^2</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      If <m>Q\vvec = \lambda\vvec</m>, then <m>\len{Q\vvec} =
-	      |\lambda|\len{\vvec}=\len{\vvec}</m> so
-	      <m>|\lambda|=1</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
     <answer>
       <p>
 	<ol marker="a.">
@@ -854,7 +829,32 @@
 	</ol>
       </p>
     </answer>
-	      
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>Q\xvec\cdot(Q\yvec) = (Q\xvec)^T\cdot(Q\yvec) =
+	      \xvec^TQ^TQ\yvec = \xvec^T\yvec=\xvec\cdot\yvec</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\len{Q\xvec}^2 = (Q\xvec)\cdot(Q\xvec) =
+	      \xvec\cdot\xvec = \len{\xvec}^2</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      If <m>Q\vvec = \lambda\vvec</m>, then <m>\len{Q\vvec} =
+	      |\lambda|\len{\vvec}=\len{\vvec}</m> so
+	      <m>|\lambda|=1</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
+
   </exercise>
 
   <exercise>
@@ -887,6 +887,30 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Since <m>Q^TQ=I</m>, we have
+	      <m>\det(Q^TQ)=\det(I)=1</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The four columns of <m>Q</m> form a basis for the
+	      column space <m>\col(QQ^T)</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      If <m>\bvec^\perp=\bvec-\bhat</m>, then <m>\bvec-\bperp
+	      = \bhat</m> is in <m>W</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -918,32 +942,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Since <m>Q^TQ=I</m>, we have
-	      <m>\det(Q^TQ)=\det(I)=1</m>. 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The four columns of <m>Q</m> form a basis for the 
-	      column space <m>\col(QQ^T)</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      If <m>\bvec^\perp=\bvec-\bhat</m>, then <m>\bvec-\bperp
-	      = \bhat</m> is in <m>W</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
       
 
@@ -999,6 +999,35 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>Q^TQ=I</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>Q^TQ=I</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec_2=\twovec{-\sin\theta}{\cos\theta}</m> or
+	      <m>\twovec{\sin\theta}{-\cos\theta}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The first column of <m>Q</m> has the form
+	      <m>\uvec_1=\twovec{\cos\theta}{\sin\theta}</m>.
+	      Now apply the result of the last part of this problem.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1034,35 +1063,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>Q^TQ=I</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>Q^TQ=I</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec_2=\twovec{-\sin\theta}{\cos\theta}</m> or
-	      <m>\twovec{\sin\theta}{-\cos\theta}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The first column of <m>Q</m> has the form
-	      <m>\uvec_1=\twovec{\cos\theta}{\sin\theta}</m>.
-	      Now apply the result of the last part of this problem.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 	      
 

--- a/src/exercises/exercises6-4.xml
+++ b/src/exercises/exercises6-4.xml
@@ -38,41 +38,6 @@
       </p>
     </statement>
 
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\wvec_1=\threevec111</m> and <m>\wvec_2 =
-	      \threevec2{-1}{-1}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec_1=\threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}</m>
-	      and <m>\uvec_2 =
-	      \threevec{2/\sqrt{6}}{-1/\sqrt{6}}{-1/\sqrt{6}}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>P = \begin{bmatrix}
-	      1 \amp 0 \amp 0 \\
-	      0 \amp 1/2 \amp 1/2 \\
-	      0 \amp 1/2 \amp 1/2 \\
-	      \end{bmatrix}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\threevec311</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
-		
     <answer>
       <p>
 	<ol marker="a.">
@@ -107,7 +72,42 @@
 	</ol>
       </p>
     </answer>
-		
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\wvec_1=\threevec111</m> and <m>\wvec_2 =
+	      \threevec2{-1}{-1}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec_1=\threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}</m>
+	      and <m>\uvec_2 =
+	      \threevec{2/\sqrt{6}}{-1/\sqrt{6}}{-1/\sqrt{6}}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>P = \begin{bmatrix}
+	      1 \amp 0 \amp 0 \\
+	      0 \amp 1/2 \amp 1/2 \\
+	      0 \amp 1/2 \amp 1/2 \\
+	      \end{bmatrix}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\threevec311</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
+
+
   </exercise>
 
   <exercise>
@@ -123,6 +123,20 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<m>Q=\begin{bmatrix}
+	2/3 \amp 1/\sqrt{5} \\
+	-1/3 \amp 2/\sqrt{5} \\
+	2/3 \amp 0
+	\end{bmatrix}</m>
+	and <m>R = \begin{bmatrix}
+	6 \amp 6 \\
+	0 \amp 3\sqrt{5}
+	\end{bmatrix}
+	</m>
+      </p>
+    </answer>
     <solution>
       <p>
 	Applying Gram-Schmidt, we have
@@ -153,20 +167,6 @@
       
     </solution>
 
-    <answer>
-      <p>
-	<m>Q=\begin{bmatrix}
-	2/3 \amp 1/\sqrt{5} \\
-	-1/3 \amp 2/\sqrt{5} \\
-	2/3 \amp 0 
-	\end{bmatrix}</m>
-	and <m>R = \begin{bmatrix}
-	6 \amp 6 \\
-	0 \amp 3\sqrt{5}
-	\end{bmatrix}
-	</m>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -235,6 +235,60 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <md>
+		\uvec_1=\threevec{1/\sqrt{3}}{-1/\sqrt{3}}{1/\sqrt{3}},
+		\hspace{24pt}
+		\uvec_2=\threevec{-1/\sqrt{2}}{-1/\sqrt{2}}{0},
+		\hspace{24pt}
+		\uvec_3=\threevec{1/\sqrt{6}}{-1/\sqrt{6}}{-2/\sqrt{6}},
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		Q = \begin{bmatrix}
+		1/\sqrt{3} \amp -1/\sqrt{2} \amp 1/\sqrt{6} \\
+		-1/\sqrt{3} \amp -1/\sqrt{2} \amp -1/\sqrt{6} \\
+		1/\sqrt{3} \amp 0 \amp -2/\sqrt{6} \\
+		\end{bmatrix},\hspace{24pt}
+		R = \begin{bmatrix}
+		2\sqrt{3} \amp \sqrt{3} \amp -\sqrt{3} \\
+		0 \amp 2\sqrt{2} \amp -\sqrt{2} \\
+		0 \amp 0 \amp 2\sqrt{6}
+		\end{bmatrix}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m>\yvec = Q^T\bvec</m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>R</m> is upper triangular
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>\xvec = \threevec{-2}1{-2}</m>
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -291,60 +345,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <md>
-		\uvec_1=\threevec{1/\sqrt{3}}{-1/\sqrt{3}}{1/\sqrt{3}},
-		\hspace{24pt}
-		\uvec_2=\threevec{-1/\sqrt{2}}{-1/\sqrt{2}}{0},
-		\hspace{24pt}
-		\uvec_3=\threevec{1/\sqrt{6}}{-1/\sqrt{6}}{-2/\sqrt{6}},
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		Q = \begin{bmatrix}
-		1/\sqrt{3} \amp -1/\sqrt{2} \amp 1/\sqrt{6} \\
-		-1/\sqrt{3} \amp -1/\sqrt{2} \amp -1/\sqrt{6} \\
-		1/\sqrt{3} \amp 0 \amp -2/\sqrt{6} \\
-		\end{bmatrix},\hspace{24pt}
-		R = \begin{bmatrix}
-		2\sqrt{3} \amp \sqrt{3} \amp -\sqrt{3} \\
-		0 \amp 2\sqrt{2} \amp -\sqrt{2} \\
-		0 \amp 0 \amp 2\sqrt{6}
-		\end{bmatrix}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>		    
-		    <m>\yvec = Q^T\bvec</m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>R</m> is upper triangular
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>\xvec = \threevec{-2}1{-2}</m>
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 	    
   <exercise>
@@ -393,6 +393,44 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <md>
+		\wvec_1 =\fivevec1{-1}{-1}11,\hspace{24pt}
+		\wvec_2 =\fivevec303{-3}3,\hspace{24pt}
+		\wvec_3 =\fivevec2022{-2},\hspace{24pt}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		\begin{bmatrix}
+		7/10 \amp -1/5 \amp 3/10 \amp 1/5 \amp 1/5 \\
+		-1/5 \amp 1/5 \amp 1/5 \amp -1/5\amp -1/5 \\
+		3/10 \amp 1/5 \amp 7/10 \amp -1/5 \amp -1/5 \\
+		1/5 \amp -1/5 \amp -1/5 \amp 7/10 \amp -3/10 \\
+		1/5 \amp -1/5 \amp -1/5 \amp -3/10 \amp 7/10 \\
+		\end{bmatrix}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bhat = \fivevec{-9}{-1}{-11}{7}{-5}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bhat = \vvec_1 - \frac83\vvec_2 -\vvec_3</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -434,46 +472,8 @@
 	</ol>
       </p>
     </solution>
-	      
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <md>
-		\wvec_1 =\fivevec1{-1}{-1}11,\hspace{24pt}
-		\wvec_2 =\fivevec303{-3}3,\hspace{24pt}
-		\wvec_3 =\fivevec2022{-2},\hspace{24pt}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		\begin{bmatrix}
-		7/10 \amp -1/5 \amp 3/10 \amp 1/5 \amp 1/5 \\
-		-1/5 \amp 1/5 \amp 1/5 \amp -1/5\amp -1/5 \\
-		3/10 \amp 1/5 \amp 7/10 \amp -1/5 \amp -1/5 \\
-		1/5 \amp -1/5 \amp -1/5 \amp 7/10 \amp -3/10 \\
-		1/5 \amp -1/5 \amp -1/5 \amp -3/10 \amp 7/10 \\
-		\end{bmatrix}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bhat = \fivevec{-9}{-1}{-11}{7}{-5}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bhat = \vvec_1 - \frac83\vvec_2 -\vvec_3</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
+
   </exercise>
 
   <exercise>
@@ -502,6 +502,23 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      We find <m>\wvec=\zerovec</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This set
+	      of vectors is linearly dependent.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -532,23 +549,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      We find <m>\wvec=\zerovec</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This set
-	      of vectors is linearly dependent.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -592,6 +592,17 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p> True </p></li>
+	  <li><p> True </p></li>
+	  <li><p> False </p></li>
+	  <li><p> True </p></li>
+	  <li><p> True </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -632,18 +643,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p> True </p></li>
-	  <li><p> True </p></li>
-	  <li><p> False </p></li>
-	  <li><p> True </p></li>
-	  <li><p> True </p></li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
   
   <exercise>
@@ -679,6 +679,32 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>7\times7</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>4\times4</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>4\times4</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      They form an orthogonal set.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -709,33 +735,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>7\times7</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>4\times4</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>4\times4</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      They form an orthogonal set.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
   </exercise>
 
   <exercise>
@@ -773,6 +773,32 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\avec_i\cdot\avec_j</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\rvec_i\cdot\rvec_j</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A^TA = (QR)^T(QR) = R^TR</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This follows from the previous parts of this exercise.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -802,33 +828,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\avec_i\cdot\avec_j</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\rvec_i\cdot\rvec_j</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A^TA = (QR)^T(QR) = R^TR</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This follows from the previous parts of this exercise.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
     
   </exercise>
 

--- a/src/exercises/exercises6-5.xml
+++ b/src/exercises/exercises6-5.xml
@@ -81,6 +81,28 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\wvec_1=\threevec12{-1}</m> and <m>
+		\wvec_2=\threevec012</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bhat = \threevec21{-8}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xvec=\twovec{-1}{-3}</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -107,28 +129,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\wvec_1=\threevec12{-1}</m> and <m>
-		\wvec_2=\threevec012</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bhat = \threevec21{-8}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xvec=\twovec{-1}{-3}</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise xml:id="ex-lst-squares-line">
@@ -204,49 +204,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
       </p>
     </statement>
 
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The matrix <m>A=\begin{bmatrix}
-	      1 \amp 1 \\
-	      1 \amp 2 \\
-	      1 \amp 3 \\
-	      1 \amp 4 \\
-	      \end{bmatrix}</m>
-	      and the vector <m>\bvec=\fourvec1112</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\begin{bmatrix}
-	      4 \amp 10 \\
-	      10 \amp 30 \\
-	      \end{bmatrix}
-	      \xhat = \twovec5{14}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xhat = \twovec{1/2}{3/10}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The predicted value is <m>y=1/2 + 3/10*3.5 = 1.55</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>R^2=0.6</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
-	      
     <answer>
       <p>
 	<ol marker="a.">
@@ -289,7 +246,50 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </answer>
-	      
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The matrix <m>A=\begin{bmatrix}
+	      1 \amp 1 \\
+	      1 \amp 2 \\
+	      1 \amp 3 \\
+	      1 \amp 4 \\
+	      \end{bmatrix}</m>
+	      and the vector <m>\bvec=\fourvec1112</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\begin{bmatrix}
+	      4 \amp 10 \\
+	      10 \amp 30 \\
+	      \end{bmatrix}
+	      \xhat = \twovec5{14}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xhat = \twovec{1/2}{3/10}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The predicted value is <m>y=1/2 + 3/10*3.5 = 1.55</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>R^2=0.6</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
+
+
   </exercise>
 
   <exercise>
@@ -456,45 +456,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
       </p>
     </statement>
 
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\begin{bmatrix}
-	      1 \amp 1 \amp 1 \\
-	      1 \amp 1 \amp 2 \\
-	      1 \amp 2 \amp 1 \\
-	      1 \amp 2 \amp 2 \\
-	      1 \amp 3 \amp 2 \\
-	      1 \amp 3 \amp 3 \\
-	      \end{bmatrix}
-	      \xvec = \begin{bmatrix}
-	      4.2 \\ 3.3 \\ 5.9 \\ 5.1 \\ 7.5 \\ 6.3
-	      \end{bmatrix}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xhat=\threevec{2.95}{2.00}{-0.85}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>2.95+2.00(2.4)-0.85(2.9) = 5.27</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>R^2=0.99</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
-	      
     <answer>
       <p>
 	<ol marker="a.">
@@ -533,7 +494,46 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </answer>
-	      
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\begin{bmatrix}
+	      1 \amp 1 \amp 1 \\
+	      1 \amp 1 \amp 2 \\
+	      1 \amp 2 \amp 1 \\
+	      1 \amp 2 \amp 2 \\
+	      1 \amp 3 \amp 2 \\
+	      1 \amp 3 \amp 3 \\
+	      \end{bmatrix}
+	      \xvec = \begin{bmatrix}
+	      4.2 \\ 3.3 \\ 5.9 \\ 5.1 \\ 7.5 \\ 6.3
+	      \end{bmatrix}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xhat=\threevec{2.95}{2.00}{-0.85}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>2.95+2.00(2.4)-0.85(2.9) = 5.27</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>R^2=0.99</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
+
+
   </exercise>
 
   <exercise>
@@ -578,6 +578,17 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li><p> True </p></li>
+	  <li><p> True </p></li>
+	  <li><p> False </p></li>
+	  <li><p> True </p></li>
+	  <li><p> False </p></li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -618,18 +629,7 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li><p> True </p></li>
-	  <li><p> True </p></li>
-	  <li><p> False </p></li>
-	  <li><p> True </p></li>
-	  <li><p> False </p></li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 	    
   <exercise>
@@ -653,6 +653,22 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\bvec</m> is in <m>\col(A)^\perp = \nul(A^T)</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xhat = A^T\bvec</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -673,22 +689,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\bvec</m> is in <m>\col(A)^\perp = \nul(A^T)</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xhat = A^T\bvec</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -759,6 +759,40 @@ list_plot(data, size=40, color='blue')
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The matrix <m>A</m> will be the <m>27\times 2</m> matrix
+	      whose first column is all 1's and whose second column is
+	      the vector of years.  The vector <m>\bvec</m> is the
+	      vector that records the number of people.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>N = 3.88\times10^9 - 1.90\times10^6t</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>R^2=0.90</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	    <m>1.14\times10^8</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      2045
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -795,41 +829,7 @@ list_plot(data, size=40, color='blue')
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The matrix <m>A</m> will be the <m>27\times 2</m> matrix
-	      whose first column is all 1's and whose second column is
-	      the vector of years.  The vector <m>\bvec</m> is the
-	      vector that records the number of people.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>N = 3.88\times10^9 - 1.90\times10^6t</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>R^2=0.90</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	    <m>1.14\times10^8</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      2045
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
   </exercise>
 
   <exercise>
@@ -911,6 +911,41 @@ print(df)
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The matrix <m>A</m> is the <m>9\times2</m> matrix whose
+	      first column is all 1's and whose second column is the
+	      vector of the logarithms of the semi-major axes.  The
+	      vector <m>\bvec</m> is the vector that records the
+	      logarithms of the periods.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>C=0.996</m> and <m>r=1.50</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>R^2=1.000</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>7.99</m> years.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>17.9</m> AU.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -953,41 +988,6 @@ print(df)
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The matrix <m>A</m> is the <m>9\times2</m> matrix whose
-	      first column is all 1's and whose second column is the
-	      vector of the logarithms of the semi-major axes.  The
-	      vector <m>\bvec</m> is the vector that records the
-	      logarithms of the periods.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>C=0.996</m> and <m>r=1.50</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>R^2=1.000</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>7.99</m> years.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>17.9</m> AU.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
   
   <exercise>
@@ -1055,6 +1055,49 @@ list_plot(data, size=40, color='blue')
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The matrix <m>A</m> will be the Vandermonde matrix of
+	      degree <m>k</m> using the altitude readings while
+	      <m>\bvec</m> is the vector of temperatures.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>k=6</m> appears to give a good fit without
+	      overfitting.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      We have
+	      <md>
+	      18.0-10.3x+0.35x^2+0.0003x^3-0.0001x^4+1.5\times10^{-6}x^5
+	      -4.7\times 10^{-9}x^6\text{.}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      A small value of <m>k</m> does not adequately track
+	      important features of the data.
+	      If we increase <m>k</m> too far, the graph tries too
+	      hard to match the data, and we see spurious features in
+	      the graph.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      We estimate the temperature to be <m>-7</m> degrees
+	      Celsius.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1099,51 +1142,8 @@ list_plot(data, size=40, color='blue')
 	</ol>
       </p>
     </solution>
-	      
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The matrix <m>A</m> will be the Vandermonde matrix of
-	      degree <m>k</m> using the altitude readings while
-	      <m>\bvec</m> is the vector of temperatures.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>k=6</m> appears to give a good fit without
-	      overfitting.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      We have
-	      <md>
-	      18.0-10.3x+0.35x^2+0.0003x^3-0.0001x^4+1.5\times10^{-6}x^5
-	      -4.7\times 10^{-9}x^6\text{.} 
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      A small value of <m>k</m> does not adequately track
-	      important features of the data.
-	      If we increase <m>k</m> too far, the graph tries too
-	      hard to match the data, and we see spurious features in
-	      the graph.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      We estimate the temperature to be <m>-7</m> degrees
-	      Celsius.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
+
   </exercise>
 
   <exercise>
@@ -1215,6 +1215,43 @@ df
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\xhat = \fourvec{\beta_0}{\beta_1}{\beta_2}{\beta_3}
+	      =
+	      \fourvec{20823}{84.7}{588.4}{-263.6}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Increasing the living area or the lot size
+	      will cause the house price to increase, but an older
+	      house will cost less.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      A house
+	      that's one year older will cost about <m>\$263.60</m> less.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>R^2=0.59</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      We estimate <m>\$177966</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1257,45 +1294,8 @@ df
 	</ol>
       </p>
     </solution>
-	      
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\xhat = \fourvec{\beta_0}{\beta_1}{\beta_2}{\beta_3}
-	      =
-	      \fourvec{20823}{84.7}{588.4}{-263.6}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Increasing the living area or the lot size
-	      will cause the house price to increase, but an older
-	      house will cost less.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      A house
-	      that's one year older will cost about <m>\$263.60</m> less.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>R^2=0.59</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      We estimate <m>\$177966</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
+
   </exercise>
 
   <exercise>
@@ -1357,6 +1357,34 @@ df
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Use the fact that <m>\xvec\cdot(A^TA\xvec)=
+	      (A\xvec)^T(A\xvec)</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      It must be true that <m>\xvec=\zerovec</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This follows from the previous two parts of this
+	      exercise.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The columns of <m>A^TA</m> must be linearly independent.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1406,35 +1434,7 @@ df
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Use the fact that <m>\xvec\cdot(A^TA\xvec)=
-	      (A\xvec)^T(A\xvec)</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      It must be true that <m>\xvec=\zerovec</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This follows from the previous two parts of this
-	      exercise.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The columns of <m>A^TA</m> must be linearly independent.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	  
+
   </exercise>
 	    
 
@@ -1536,6 +1536,44 @@ df
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\bvec\cdot\onevec</m> simply sums the components of
+	      <m>\bvec</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\onevec</m> is a column of <m>A</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bperp</m> is in <m>\col(A)^\perp</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Use the fact that <m>\bhat</m> and <m>\bperp</m> are orthogonal.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This follows from <m>\bvec = \bhat + \bperp</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This follow from <m>\var(\bvec) = \var(\bhat) +
+	      \var(\bperp)</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1616,44 +1654,6 @@ df
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\bvec\cdot\onevec</m> simply sums the components of
-	      <m>\bvec</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\onevec</m> is a column of <m>A</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bperp</m> is in <m>\col(A)^\perp</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Use the fact that <m>\bhat</m> and <m>\bperp</m> are orthogonal.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This follows from <m>\bvec = \bhat + \bperp</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This follow from <m>\var(\bvec) = \var(\bhat) +
-	      \var(\bperp)</m>. 
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises7-1.xml
+++ b/src/exercises/exercises7-1.xml
@@ -63,6 +63,65 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Not diagonalizable
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		D = \begin{bmatrix}
+		1 \amp 0 \\
+		0 \amp -1 \\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		1/\sqrt{2} \amp 1/\sqrt{2} \\
+		1/\sqrt{2} \amp -1/\sqrt{2} \\
+		\end{bmatrix}\text{.}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Diagonalizable, but not orthogonally
+	      diagonalizable.
+	      <md>
+		D = \begin{bmatrix}
+		4 \amp 0 \amp 0 \\
+		0 \amp 1 \amp 0 \\
+		0 \amp 0 \amp 2 \\
+		\end{bmatrix},\hspace{24pt}
+		P = \begin{bmatrix}
+		0 \amp 9 \amp 0 \\
+		0 \amp 6 \amp 6 \\
+		1 \amp -2 \amp -1
+		\end{bmatrix}\text{.}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		D = \begin{bmatrix}
+		6 \amp 0 \amp 0 \\
+		0 \amp 3 \amp 0 \\
+		0 \amp 0 \amp -12 \\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
+		0 \amp 1/\sqrt{3} \amp -2/\sqrt{6} \\
+		-1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
+		\end{bmatrix}\text{.}
+	      </md>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -126,67 +185,8 @@
 	</ol>
       </p>
     </solution>
-	      
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Not diagonalizable
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		D = \begin{bmatrix}
-		1 \amp 0 \\
-		0 \amp -1 \\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		1/\sqrt{2} \amp 1/\sqrt{2} \\
-		1/\sqrt{2} \amp -1/\sqrt{2} \\
-		\end{bmatrix}\text{.}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Diagonalizable, but not orthogonally
-	      diagonalizable.
-	      <md>
-		D = \begin{bmatrix}
-		4 \amp 0 \amp 0 \\
-		0 \amp 1 \amp 0 \\
-		0 \amp 0 \amp 2 \\
-		\end{bmatrix},\hspace{24pt}
-		P = \begin{bmatrix}
-		0 \amp 9 \amp 0 \\
-		0 \amp 6 \amp 6 \\
-		1 \amp -2 \amp -1
-		\end{bmatrix}\text{.}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		D = \begin{bmatrix}
-		6 \amp 0 \amp 0 \\
-		0 \amp 3 \amp 0 \\
-		0 \amp 0 \amp -12 \\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
-		0 \amp 1/\sqrt{3} \amp -2/\sqrt{6} \\
-		-1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
-		\end{bmatrix}\text{.}
-	      </md>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 
   <exercise>
@@ -241,6 +241,52 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Because of the Spectral Theorem
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec_1=\threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\vvec_1 = \threevec10{-1}</m> and
+	      <m>\vvec_2=\threevec01{-1}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec_2 = \threevec{1/\sqrt{2}}0{-1/\sqrt{2}}</m> and
+	      <m>\uvec_3 =
+	      \threevec{-1/\sqrt{6}}{2/\sqrt{6}}{-1/\sqrt{6}}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		D = \begin{bmatrix}
+		5 \amp 0 \amp 0 \\
+		0 \amp -1 \amp 0 \\
+		0 \amp 0 \amp -1 \\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		1/\sqrt{3} \amp 1/\sqrt{2} \amp -1/\sqrt{6} \\
+		1/\sqrt{3} \amp 0 \amp 2/\sqrt{6} \\
+		1/\sqrt{3} \amp -1/\sqrt{2} \amp -1/\sqrt{6} \\
+		\end{bmatrix}\text{.}
+	      </md>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -288,54 +334,8 @@
 	</ol>
       </p>
     </solution>
-	  
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Because of the Spectral Theorem
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec_1=\threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\vvec_1 = \threevec10{-1}</m> and
-	      <m>\vvec_2=\threevec01{-1}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec_2 = \threevec{1/\sqrt{2}}0{-1/\sqrt{2}}</m> and
-	      <m>\uvec_3 =
-	      \threevec{-1/\sqrt{6}}{2/\sqrt{6}}{-1/\sqrt{6}}</m> 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		D = \begin{bmatrix}
-		5 \amp 0 \amp 0 \\
-		0 \amp -1 \amp 0 \\
-		0 \amp 0 \amp -1 \\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		1/\sqrt{3} \amp 1/\sqrt{2} \amp -1/\sqrt{6} \\
-		1/\sqrt{3} \amp 0 \amp 2/\sqrt{6} \\
-		1/\sqrt{3} \amp -1/\sqrt{2} \amp -1/\sqrt{6} \\
-		\end{bmatrix}\text{.}
-	      </md>		
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-      
+
+
   </exercise>
 
   <exercise>
@@ -389,53 +389,6 @@
       </p>
     </statement>
 
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <md>
-		D = \begin{bmatrix}
-		21 \amp 0 \amp 0 \\
-		0 \amp 9 \amp 0 \\
-		0 \amp 0 \amp -21 \\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		2/3 \amp 2/3 \amp 1/3 \\
-		-1/3 \amp 2/3 \amp -2/3 \\
-		2/3 \amp -1/3 \amp -2/3 \\
-		\end{bmatrix}\text{.}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This matrix is not symmetric so it is not orthogonally
-	      diagonalizable.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		D = \begin{bmatrix}
-		18 \amp 0 \amp 0 \amp 0 \\
-		0 \amp 6 \amp 0 \amp 0 \\
-		0 \amp 0 \amp 6 \amp 0\\
-		0 \amp 0 \amp 0 \amp 6\\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		1/2 \amp 1/\sqrt{2} \amp -1/\sqrt{6} \amp -1/\sqrt{12} \\
-		1/2 \amp 0 \amp 2/\sqrt{6} \amp -1/\sqrt{12} \\
-		1/2 \amp 0 \amp 0 \amp 3/\sqrt{12} \\
-		1/2 \amp -1/\sqrt{2} \amp -1/\sqrt{6} \amp -1/\sqrt{12} \\
-		\end{bmatrix}\text{.}
-	      </md>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
-	      
     <answer>
       <p>
 	<ol marker="a.">
@@ -482,7 +435,54 @@
 	</ol>
       </p>
     </answer>
-		
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <md>
+		D = \begin{bmatrix}
+		21 \amp 0 \amp 0 \\
+		0 \amp 9 \amp 0 \\
+		0 \amp 0 \amp -21 \\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		2/3 \amp 2/3 \amp 1/3 \\
+		-1/3 \amp 2/3 \amp -2/3 \\
+		2/3 \amp -1/3 \amp -2/3 \\
+		\end{bmatrix}\text{.}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This matrix is not symmetric so it is not orthogonally
+	      diagonalizable.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		D = \begin{bmatrix}
+		18 \amp 0 \amp 0 \amp 0 \\
+		0 \amp 6 \amp 0 \amp 0 \\
+		0 \amp 0 \amp 6 \amp 0\\
+		0 \amp 0 \amp 0 \amp 6\\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		1/2 \amp 1/\sqrt{2} \amp -1/\sqrt{6} \amp -1/\sqrt{12} \\
+		1/2 \amp 0 \amp 2/\sqrt{6} \amp -1/\sqrt{12} \\
+		1/2 \amp 0 \amp 0 \amp 3/\sqrt{12} \\
+		1/2 \amp -1/\sqrt{2} \amp -1/\sqrt{6} \amp -1/\sqrt{12} \\
+		\end{bmatrix}\text{.}
+	      </md>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
+
+
   </exercise>
 
   <exercise>
@@ -525,6 +525,39 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>B</m> is symmetric
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\vvec\cdot(A^TA\vvec) =
+	      (A\vvec)\cdot(A\vvec)</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>|A\uvec|^2 = \lambda</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\lambda=|A\uvec|^2 \geq 0</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec\cdot(C\uvec) = \frac1N(A^T\uvec)\cdot(A^T\uvec)
+	      = \frac1N |A^T\uvec|^2</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -563,41 +596,8 @@
 	</ol>
       </p>
     </solution>
-    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>B</m> is symmetric
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\vvec\cdot(A^TA\vvec) =
-	      (A\vvec)\cdot(A\vvec)</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>|A\uvec|^2 = \lambda</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\lambda=|A\uvec|^2 \geq 0</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec\cdot(C\uvec) = \frac1N(A^T\uvec)\cdot(A^T\uvec)
-	      = \frac1N |A^T\uvec|^2</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 
   <exercise>
@@ -650,6 +650,46 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+      <ol marker="a.">
+	<li>
+	  <p>
+	    <md>
+	      \twovec{-1}{-2},\twovec{-1}{1},\twovec1{-1},\twovec{0}{0},
+	      \twovec12
+	    </md>
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    <m>V = 14/5</m>
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    <m>V_{\evec_1} = 4/5</m> and <m>V_{\evec_2} = 2</m>
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    <m>34/25</m>
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    <m>36/24</m>
+	  </p>
+	</li>
+	<li>
+	  <p>
+	    The variances add to the toal
+	    variance.
+	  </p>
+	</li>
+      </ol>
+      </p>
+    </answer>
     <solution>
       <p>
       <ol marker="a.">
@@ -692,48 +732,8 @@
       </ol>
       </p>
     </solution>
-      
-    <answer>
-      <p>
-      <ol marker="a.">
-	<li>
-	  <p>
-	    <md>
-	      \twovec{-1}{-2},\twovec{-1}{1},\twovec1{-1},\twovec{0}{0},
-	      \twovec12
-	    </md>
-	  </p>
-	</li>
-	<li>
-	  <p>
-	    <m>V = 14/5</m>
-	  </p>
-	</li>
-	<li>
-	  <p>
-	    <m>V_{\evec_1} = 4/5</m> and <m>V_{\evec_2} = 2</m>
-	  </p>
-	</li>
-	<li>
-	  <p>
-	    <m>34/25</m>
-	  </p>
-	</li>
-	<li>
-	  <p>
-	    <m>36/24</m>
-	  </p>
-	</li>
-	<li>
-	  <p>
-	    The variances add to the toal
-	    variance.
-	  </p>
-	</li>
-      </ol>
-      </p>
-    </answer>
-      
+
+
   </exercise>
 
   <exercise>
@@ -800,6 +800,54 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>A = \begin{bmatrix}
+	      -1 \amp -3 \amp 1 \amp 1 \amp 2 \amp 0 \\
+	      -2 \amp -3 \amp 0 \amp 2 \amp 1 \amp 2
+	      \end{bmatrix}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>C=\begin{bmatrix}
+	      8/3 \amp 5/2 \\
+	      5/2 \amp 11/3
+	      \end{bmatrix}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		D = \begin{bmatrix}
+		5.72 \amp 0 \\
+		0 \amp 0.62 \\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		0.63 \amp 0.77 \\
+		0.77 \amp -0.63 \\
+		\end{bmatrix}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec_1=\twovec{0.63}{0.77}</m>
+	      and <m>\uvec_2=\twovec{0.77}{-0.63}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>V_{\uvec_1}=5.72</m>
+	      and <m>V_{\uvec_2} = 0.62</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -851,54 +899,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>A = \begin{bmatrix}
-	      -1 \amp -3 \amp 1 \amp 1 \amp 2 \amp 0 \\
-	      -2 \amp -3 \amp 0 \amp 2 \amp 1 \amp 2
-	      \end{bmatrix}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>C=\begin{bmatrix}
-	      8/3 \amp 5/2 \\
-	      5/2 \amp 11/3
-	      \end{bmatrix}</m> 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		D = \begin{bmatrix}
-		5.72 \amp 0 \\
-		0 \amp 0.62 \\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		0.63 \amp 0.77 \\
-		0.77 \amp -0.63 \\
-		\end{bmatrix}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec_1=\twovec{0.63}{0.77}</m>
-	      and <m>\uvec_2=\twovec{0.77}{-0.63}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>V_{\uvec_1}=5.72</m>
-	      and <m>V_{\uvec_2} = 0.62</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
 
   </exercise>
 
@@ -943,29 +943,6 @@
       </p>
     </statement>
     
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The variance is <m>V_{\uvec} = \uvec\cdot(C\uvec) =
-	      \lambda\uvec\cdot\uvec = \lambda</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>V_{\uvec_2} = 0</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>V=V_{\uvec_1}+V_{\uvec_2} = \lambda_1+\lambda_2</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
-	      
     <answer>
       <p>
 	<ol marker="a.">
@@ -988,7 +965,30 @@
 	</ol>
       </p>
     </answer>
-	      
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The variance is <m>V_{\uvec} = \uvec\cdot(C\uvec) =
+	      \lambda\uvec\cdot\uvec = \lambda</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>V_{\uvec_2} = 0</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>V=V_{\uvec_1}+V_{\uvec_2} = \lambda_1+\lambda_2</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
+
+
   </exercise>
 
   <exercise>
@@ -1033,6 +1033,37 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      True.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1074,38 +1105,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      True.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True. 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -1124,6 +1124,22 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<md>
+	  D = \begin{bmatrix}
+	  20 \amp 0 \amp 0 \\
+	  0 \amp -4 \amp 0 \\
+	  0 \amp 0 \amp 0 \\
+	  \end{bmatrix},\hspace{24pt}
+	  Q = \begin{bmatrix}
+	  2/3 \amp 1/\sqrt{18} \amp -1/\sqrt{2} \\
+	  -1/3 \amp 4/\sqrt{18} \amp 0 \\
+	  2/3 \amp 1/\sqrt{18} \amp 1/\sqrt{2} \\
+	  \end{bmatrix}
+	</md>
+      </p>
+    </answer>
     <solution>
       <p>
 	Since <m>A</m> is not invertible, the third eigenvalue must be
@@ -1147,24 +1163,8 @@
 	</md>
       </p>
     </solution>
-	
-    <answer>
-      <p>
-	<md>
-	  D = \begin{bmatrix}
-	  20 \amp 0 \amp 0 \\
-	  0 \amp -4 \amp 0 \\
-	  0 \amp 0 \amp 0 \\
-	  \end{bmatrix},\hspace{24pt}
-	  Q = \begin{bmatrix}
-	  2/3 \amp 1/\sqrt{18} \amp -1/\sqrt{2} \\
-	  -1/3 \amp 4/\sqrt{18} \amp 0 \\
-	  2/3 \amp 1/\sqrt{18} \amp 1/\sqrt{2} \\
-	  \end{bmatrix}
-	</md>
-      </p>
-    </answer>
-	
+
+
   </exercise>
 
   <exercise>
@@ -1195,6 +1195,27 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>P</m> is symmetric
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      0 or 1
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The eigenspaces <m>E_1=W</m> and <m>E_0=W^{\perp}</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1224,28 +1245,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>P</m> is symmetric 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      0 or 1
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The eigenspaces <m>E_1=W</m> and <m>E_0=W^{\perp}</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
   </exercise>
 	    
 </exercises>

--- a/src/exercises/exercises7-2.xml
+++ b/src/exercises/exercises7-2.xml
@@ -39,6 +39,44 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>A = QDQ^T</m> where
+	      <md>
+		D=\begin{bmatrix}
+		8 \amp 0 \\
+		0 \amp 3 \\
+		\end{bmatrix},\hspace{24pt}
+		Q=\begin{bmatrix}
+		1/\sqrt{5} \amp 2/\sqrt{5} \\
+		2/\sqrt{5} \amp -1/\sqrt{5} \\
+		\end{bmatrix}\text{.}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>15</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The maximum value is <m>8</m> in the direction
+	      <m>\twovec{1/\sqrt{5}}{2/\sqrt{5}}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The minimum value is <m>3</m> in the direction
+	      <m>\twovec{2/\sqrt{5}}{-1/\sqrt{5}}</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -78,46 +116,8 @@
 	</ol>
       </p>
     </solution>
-	  
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>A = QDQ^T</m> where
-	      <md>
-		D=\begin{bmatrix}
-		8 \amp 0 \\
-		0 \amp 3 \\
-		\end{bmatrix},\hspace{24pt}
-		Q=\begin{bmatrix}
-		1/\sqrt{5} \amp 2/\sqrt{5} \\
-		2/\sqrt{5} \amp -1/\sqrt{5} \\
-		\end{bmatrix}\text{.}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>15</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The maximum value is <m>8</m> in the direction
-	      <m>\twovec{1/\sqrt{5}}{2/\sqrt{5}}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The minimum value is <m>3</m> in the direction
-	      <m>\twovec{2/\sqrt{5}}{-1/\sqrt{5}}</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	  
+
+
   </exercise>
 
   <exercise>
@@ -229,37 +229,6 @@
       </p>
     </statement>
 
-    <solution>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>C = \frac14 AA^T = \begin{bmatrix}
-	      3/2 \amp 1 \\
-	      1 \amp 1
-	      \end{bmatrix}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>V_{\uvec} = \uvec\cdot(C\uvec) = 9/4</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The total variance is <m>V_x+V_y = 3/2+1=5/2</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The variance is greatest in the direction
-	      <m>\uvec=\twovec{0.79}{0.62}</m> where
-	      <m>V_{\uvec}=2.28</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </solution>
     <answer>
       <p>
 	<ol marker="a.">
@@ -291,6 +260,37 @@
 	</ol>
       </p>
     </answer>
+    <solution>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>C = \frac14 AA^T = \begin{bmatrix}
+	      3/2 \amp 1 \\
+	      1 \amp 1
+	      \end{bmatrix}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>V_{\uvec} = \uvec\cdot(C\uvec) = 9/4</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The total variance is <m>V_x+V_y = 3/2+1=5/2</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The variance is greatest in the direction
+	      <m>\uvec=\twovec{0.79}{0.62}</m> where
+	      <m>V_{\uvec}=2.28</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </solution>
   </exercise>
 
   <exercise>
@@ -327,6 +327,43 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <md>
+		D = \begin{bmatrix}
+		7 \amp 0 \amp 0 \\
+		0 \amp 7 \amp 0 \\
+		0 \amp 0 \amp -2 \\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		1/\sqrt{2} \amp -1/\sqrt{6} \amp 1/\sqrt{3} \\
+		0 \amp 2/\sqrt{6} \amp 1/\sqrt{3} \\
+		-1/\sqrt{2} \amp -1/\sqrt{6} \amp 1/\sqrt{3} \\
+		\end{bmatrix}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The maximum is 7 and the minimum is -2.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The minimum occurs in the direction of
+	      <m>\threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}</m>.
+	      The maximum occurs along a circle defined by
+	      <m>c_1\uvec_1+c_2\uvec_2</m> where <m>c_1^2+c_2^2=1</m>
+	      and <m>\uvec_1</m> and <m>\uvec_2</m> are the first two
+	      columns of <m>Q</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -364,45 +401,8 @@
 	</ol>
       </p>
     </solution>
-	
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <md>
-		D = \begin{bmatrix}
-		7 \amp 0 \amp 0 \\
-		0 \amp 7 \amp 0 \\
-		0 \amp 0 \amp -2 \\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		1/\sqrt{2} \amp -1/\sqrt{6} \amp 1/\sqrt{3} \\
-		0 \amp 2/\sqrt{6} \amp 1/\sqrt{3} \\
-		-1/\sqrt{2} \amp -1/\sqrt{6} \amp 1/\sqrt{3} \\
-		\end{bmatrix}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The maximum is 7 and the minimum is -2.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The minimum occurs in the direction of
-	      <m>\threevec{1/\sqrt{3}}{1/\sqrt{3}}{1/\sqrt{3}}</m>.
-	      The maximum occurs along a circle defined by 
-	      <m>c_1\uvec_1+c_2\uvec_2</m> where <m>c_1^2+c_2^2=1</m>
-	      and <m>\uvec_1</m> and <m>\uvec_2</m> are the first two
-	      columns of <m>Q</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	
+
+
   </exercise>
 
   <exercise>
@@ -436,6 +436,34 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>A = B^TB=\begin{bmatrix}
+	      24 \amp -12 \\
+	      -12 \amp 6 \\
+	      \end{bmatrix}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The maximum value is <m>30</m> in the direction
+	      <m>\twovec{2/\sqrt{5}}{-1/\sqrt{5}}</m> and the minimum
+	      value is <m>0</m> in the direction
+	      <m>\twovec{1/\sqrt{5}}{2/\sqrt{5}}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The columns of <m>B</m> are linearly
+	      dependent.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -469,34 +497,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>A = B^TB=\begin{bmatrix}
-	      24 \amp -12 \\
-	      -12 \amp 6 \\
-	      \end{bmatrix}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The maximum value is <m>30</m> in the direction
-	      <m>\twovec{2/\sqrt{5}}{-1/\sqrt{5}}</m> and the minimum
-	      value is <m>0</m> in the direction 
-	      <m>\twovec{1/\sqrt{5}}{2/\sqrt{5}}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The columns of <m>B</m> are linearly
-	      dependent.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -532,6 +532,34 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>A</m> is positive definite.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>Q=\begin{bmatrix}
+	      1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
+	      0 \amp -1/\sqrt{3} \amp 2/\sqrt{6} \\
+	      -1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
+	      \end{bmatrix}
+	      </m> and <m>
+	      q_A(\xvec) = 9y_1^2 + 6y_2^2 + 3y_3^2</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The maximum value is <m>9</m> and the minimum value is
+	      <m>3</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -567,34 +595,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>A</m> is positive definite.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>Q=\begin{bmatrix}
-	      1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
-	      0 \amp -1/\sqrt{3} \amp 2/\sqrt{6} \\
-	      -1/\sqrt{2} \amp 1/\sqrt{3} \amp 1/\sqrt{6} \\
-	      \end{bmatrix}
-	      </m> and <m>
-	      q_A(\xvec) = 9y_1^2 + 6y_2^2 + 3y_3^2</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The maximum value is <m>9</m> and the minimum value is
-	      <m>3</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -625,6 +625,31 @@
 	</ol>
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>q(\uvec) =
+	      |B\uvec|^2 = \lambda \geq 0</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>q_{A+B}(\xvec)
+	      = q_A(\xvec) +
+	      q_B(\xvec) \gt 0</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The eigenvalues of <m>A^{-1}</m> are the reciprocals of
+	      the eigenvalues of <m>A</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -656,33 +681,8 @@
 	</ol>
       </p>
     </solution>
-    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>q(\uvec) = 
-	      |B\uvec|^2 = \lambda \geq 0</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>q_{A+B}(\xvec) 
-	      = q_A(\xvec) +
-	      q_B(\xvec) \gt 0</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The eigenvalues of <m>A^{-1}</m> are the reciprocals of
-	      the eigenvalues of <m>A</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-    
+
+
   </exercise>
 
   <exercise>
@@ -728,6 +728,37 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -775,37 +806,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -830,6 +830,24 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>(\sqrt[3]{2}, \sqrt[3]{2})</m> is neither a local
+	      maximum nor minimum.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>(0,0)</m> is neither a local maximum nor minimum.
+	      Both <m>(1,1)</m> and <m>(-1,-1)</m> are local minima.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -888,24 +906,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>(\sqrt[3]{2}, \sqrt[3]{2})</m> is neither a local
-	      maximum nor minimum.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>(0,0)</m> is neither a local maximum nor minimum.
-	      Both <m>(1,1)</m> and <m>(-1,-1)</m> are local minima.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -937,6 +937,32 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The Hessian matrix at that point is
+	      <m>H=\begin{bmatrix}
+	      12 \amp 4 \amp -4 \\
+	      4 \amp 12 \amp 4 \\
+	      -4 \amp 4 \amp 12
+	      \end{bmatrix} </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>H</m> is positive definite.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The critical point is a local minimum.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -979,32 +1005,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The Hessian matrix at that point is
-	      <m>H=\begin{bmatrix}
-	      12 \amp 4 \amp -4 \\
-	      4 \amp 12 \amp 4 \\
-	      -4 \amp 4 \amp 12
-	      \end{bmatrix} </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>H</m> is positive definite.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The critical point is a local minimum.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises7-3.xml
+++ b/src/exercises/exercises7-3.xml
@@ -46,6 +46,29 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m> 149</m> for the first dataset and <m>101</m> for the
+	      second
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>50.3\%</m> and <m>99.0\%</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The points in the second set are clustered very close to
+	      a line.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -76,30 +99,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m> 149</m> for the first dataset and <m>101</m> for the
-	      second
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>50.3\%</m> and <m>99.0\%</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The points in the second set are clustered very close to
-	      a line.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	  
+
   </exercise>
 
   <exercise>
@@ -146,6 +146,27 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>97\%</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\twovec{25.4}{8.16}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m> \threevec{9.7}{-22.3}{3.7}</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -175,29 +196,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>97\%</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\twovec{25.4}{8.16}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m> \threevec{9.7}{-22.3}{3.7}</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
 	      
   </exercise>
 
@@ -237,6 +237,28 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The variances are <m>V_{\uvec_1} = 1.62</m> and
+	      <m>V_{\uvec_2} = 0</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>1.62</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      All of the data lies on a line
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -261,28 +283,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The variances are <m>V_{\uvec_1} = 1.62</m> and
-	      <m>V_{\uvec_2} = 0</m>. 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>1.62</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      All of the data lies on a line 
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -319,6 +319,27 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -346,27 +367,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -406,6 +406,29 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The petal length is the most signficant and the sepal
+	      width is the least.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Iris setosa has a below average petal length and appears
+	      overall smaller.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Iris versicolor
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -443,31 +466,8 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The petal length is the most signficant and the sepal
-	      width is the least.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Iris setosa has a below average petal length and appears
-	      overall smaller.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Iris versicolor
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 	    
   <exercise>
@@ -607,6 +607,45 @@ pca_plot(B, sex='female')
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>2.7</m>, <m>0.8</m>, <m>0.4</m>,
+	      <m>0.1</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>88\%</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>B=Q^TA</m> where the columns of <m>Q</m> are the
+	      first two principal components.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Gentoo penguins have a larger body mass.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      These measurements seem larger for the Chinstrap
+	      penguins.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The male Gentoo have a higher body mass.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -654,46 +693,7 @@ pca_plot(B, sex='female')
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>2.7</m>, <m>0.8</m>, <m>0.4</m>,
-	      <m>0.1</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>88\%</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>B=Q^TA</m> where the columns of <m>Q</m> are the
-	      first two principal components.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Gentoo penguins have a larger body mass.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      These measurements seem larger for the Chinstrap
-	      penguins.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The male Gentoo have a higher body mass.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-    
+
   </exercise>
 
 </exercises>

--- a/src/exercises/exercises7-4.xml
+++ b/src/exercises/exercises7-4.xml
@@ -51,6 +51,74 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>G = \begin{bmatrix}
+	      1 \amp 2 \amp 1 \\
+	      2 \amp 5 \amp 0 \\
+	      1 \amp 0 \amp 5 \\
+	      \end{bmatrix}</m>, which has
+	      <md>
+		D=\begin{bmatrix}
+		6 \amp 0 \amp 0 \\
+		0 \amp 5 \amp 0 \\
+		0 \amp 0 \amp 0 \\
+		\end{bmatrix},\hspace{24pt}
+		Q = \begin{bmatrix}
+		1/\sqrt{6} \amp 0 \amp 5/\sqrt{30} \\
+		2/\sqrt{6} \amp 1/\sqrt{5} \amp -2/\sqrt{30} \\
+		1/\sqrt{6} \amp -2/\sqrt{5} \amp -1/\sqrt{30} \\
+		\end{bmatrix}
+	      </md>
+	    </p>
+	    <p>
+	      <m>\sigma_1 = \sqrt{6}</m> and
+	      <m>\sigma_2=\sqrt{5}</m>.  The right singular vectors
+	      are the columns of <m>Q</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\uvec_1 = \twovec10</m> and
+	      <m>\uvec_2=\twovec0{-1}</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <md>
+		U=\begin{bmatrix}
+		1 \amp 0 \\
+		0 \amp -1 \\
+		\end{bmatrix},\hspace{24pt}
+		\Sigma = \begin{bmatrix}
+		\sqrt{6} \amp 0 \amp 0 \\
+		0 \amp \sqrt{5} \amp 0 \\
+		\end{bmatrix},\hspace{24pt}
+		V = \begin{bmatrix}
+		1/\sqrt{6} \amp 0 \amp 5/\sqrt{30} \\
+		2/\sqrt{6} \amp 1/\sqrt{5} \amp -2/\sqrt{30} \\
+		1/\sqrt{6} \amp -2/\sqrt{5} \amp -1/\sqrt{30} \\
+		\end{bmatrix}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\rank(A)=2</m> and <m>\col(A)=\real^2</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\vvec_3 =
+	      \threevec{5/\sqrt{30}}{-2/\sqrt{30}}{-1/\sqrt{30}}</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -121,75 +189,7 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>G = \begin{bmatrix}
-	      1 \amp 2 \amp 1 \\
-	      2 \amp 5 \amp 0 \\
-	      1 \amp 0 \amp 5 \\
-	      \end{bmatrix}</m>, which has
-	      <md>
-		D=\begin{bmatrix}
-		6 \amp 0 \amp 0 \\
-		0 \amp 5 \amp 0 \\
-		0 \amp 0 \amp 0 \\
-		\end{bmatrix},\hspace{24pt}
-		Q = \begin{bmatrix}
-		1/\sqrt{6} \amp 0 \amp 5/\sqrt{30} \\
-		2/\sqrt{6} \amp 1/\sqrt{5} \amp -2/\sqrt{30} \\
-		1/\sqrt{6} \amp -2/\sqrt{5} \amp -1/\sqrt{30} \\
-		\end{bmatrix}
-	      </md>
-	    </p>
-	    <p>
-	      <m>\sigma_1 = \sqrt{6}</m> and
-	      <m>\sigma_2=\sqrt{5}</m>.  The right singular vectors
-	      are the columns of <m>Q</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\uvec_1 = \twovec10</m> and
-	      <m>\uvec_2=\twovec0{-1}</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <md>
-		U=\begin{bmatrix}
-		1 \amp 0 \\
-		0 \amp -1 \\
-		\end{bmatrix},\hspace{24pt}
-		\Sigma = \begin{bmatrix}
-		\sqrt{6} \amp 0 \amp 0 \\
-		0 \amp \sqrt{5} \amp 0 \\
-		\end{bmatrix},\hspace{24pt}
-		V = \begin{bmatrix}
-		1/\sqrt{6} \amp 0 \amp 5/\sqrt{30} \\
-		2/\sqrt{6} \amp 1/\sqrt{5} \amp -2/\sqrt{30} \\
-		1/\sqrt{6} \amp -2/\sqrt{5} \amp -1/\sqrt{30} \\
-		\end{bmatrix}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\rank(A)=2</m> and <m>\col(A)=\real^2</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\vvec_3 =
-	      \threevec{5/\sqrt{30}}{-2/\sqrt{30}}{-1/\sqrt{30}}</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
+
 
   </exercise>
 
@@ -234,6 +234,100 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\begin{bmatrix}
+	      0 \amp 0 \\
+	      0 \amp -8 \\
+	      \end{bmatrix} =
+	      \begin{bmatrix}
+	      0 \amp 1 \\
+	      -1 \amp 0 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      8 \amp 0 \\
+	      0 \amp 0 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      1 \amp 0 \\
+	      0 \amp 1 \\
+	      \end{bmatrix}^T
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\begin{bmatrix}
+	      2 \amp 3 \\
+	      0 \amp 2 \\
+	      \end{bmatrix} =
+	      \begin{bmatrix}
+	      2/\sqrt{5} \amp 1/\sqrt{5} \\
+	      1/\sqrt{5} \amp -2/\sqrt{5} \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      4 \amp 0 \\
+	      0 \amp 1 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      1/\sqrt{5} \amp 2/\sqrt{5} \\
+	      2/\sqrt{5} \amp -1/\sqrt{5} \\
+	      \end{bmatrix}^T
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\begin{bmatrix}
+	      4 \amp 0 \amp 0 \\
+	      0 \amp 0 \amp 2 \\
+	      \end{bmatrix} =
+	      \begin{bmatrix}
+	      1 \amp 0 \\
+	      0 \amp 1 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      4 \amp 0 \amp 0 \\
+	      0 \amp 2 \amp 0 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      1 \amp 0 \amp 0 \\
+	      0 \amp 0 \amp 1 \\
+	      0 \amp 1 \amp 0 \\
+	      \end{bmatrix}^T
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\begin{bmatrix}
+	      4 \amp 0 \\
+	      0 \amp 0 \\
+	      0 \amp 2 \\
+	      \end{bmatrix} =
+	      \begin{bmatrix}
+	      1 \amp 0 \amp 0 \\
+	      0 \amp 0 \amp 1 \\
+	      0 \amp 1 \amp 0 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      4 \amp 0 \\
+	      0 \amp 2 \\
+	      0 \amp 0 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      1 \amp 0 \\
+	      0 \amp 1 \\
+	      \end{bmatrix}^T
+	      </m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -328,102 +422,8 @@
 	</ol>
       </p>
     </solution>
-	
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\begin{bmatrix}
-	      0 \amp 0 \\
-	      0 \amp -8 \\
-	      \end{bmatrix} = 
-	      \begin{bmatrix}
-	      0 \amp 1 \\
-	      -1 \amp 0 \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      8 \amp 0 \\
-	      0 \amp 0 \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      1 \amp 0 \\
-	      0 \amp 1 \\
-	      \end{bmatrix}^T
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\begin{bmatrix}
-	      2 \amp 3 \\
-	      0 \amp 2 \\
-	      \end{bmatrix} = 
-	      \begin{bmatrix}
-	      2/\sqrt{5} \amp 1/\sqrt{5} \\
-	      1/\sqrt{5} \amp -2/\sqrt{5} \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      4 \amp 0 \\
-	      0 \amp 1 \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      1/\sqrt{5} \amp 2/\sqrt{5} \\
-	      2/\sqrt{5} \amp -1/\sqrt{5} \\
-	      \end{bmatrix}^T
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\begin{bmatrix}
-	      4 \amp 0 \amp 0 \\
-	      0 \amp 0 \amp 2 \\
-	      \end{bmatrix} = 
-	      \begin{bmatrix}
-	      1 \amp 0 \\
-	      0 \amp 1 \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      4 \amp 0 \amp 0 \\
-	      0 \amp 2 \amp 0 \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      1 \amp 0 \amp 0 \\
-	      0 \amp 0 \amp 1 \\
-	      0 \amp 1 \amp 0 \\
-	      \end{bmatrix}^T
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\begin{bmatrix}
-	      4 \amp 0 \\
-	      0 \amp 0 \\
-	      0 \amp 2 \\
-	      \end{bmatrix} = 
-	      \begin{bmatrix}
-	      1 \amp 0 \amp 0 \\
-	      0 \amp 0 \amp 1 \\
-	      0 \amp 1 \amp 0 \\
-	      \end{bmatrix}
-	      \begin{bmatrix}
-	      4 \amp 0 \\
-	      0 \amp 2 \\
-	      0 \amp 0 \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      1 \amp 0 \\
-	      0 \amp 1 \\
-	      \end{bmatrix}^T
-	      </m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	
+
+
   </exercise>
 
   <exercise>
@@ -455,6 +455,41 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\begin{bmatrix}
+	      2 \amp 1 \\
+	      1 \amp 2 \\
+	      \end{bmatrix} =
+	      \begin{bmatrix}
+	      1/\sqrt{2} \amp 1/\sqrt{2} \\
+	      1/\sqrt{2} \amp -1/\sqrt{2} \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      3 \amp 0 \\
+	      0 \amp 1 \\
+	      \end{bmatrix}
+	      \begin{bmatrix}
+	      1/\sqrt{2} \amp 1/\sqrt{2} \\
+	      1/\sqrt{2} \amp -1/\sqrt{2} \\
+	      \end{bmatrix}^T
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The singular values
+	      <m>\sigma_i = \lambda_i</m>, the eigenvalues of <m>A</m>
+	      and the right singular vectors are eigenvectors of
+	      <m>A</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -502,42 +537,7 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\begin{bmatrix}
-	      2 \amp 1 \\
-	      1 \amp 2 \\
-	      \end{bmatrix} = 
-	      \begin{bmatrix}
-	      1/\sqrt{2} \amp 1/\sqrt{2} \\
-	      1/\sqrt{2} \amp -1/\sqrt{2} \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      3 \amp 0 \\
-	      0 \amp 1 \\
-	      \end{bmatrix} 
-	      \begin{bmatrix}
-	      1/\sqrt{2} \amp 1/\sqrt{2} \\
-	      1/\sqrt{2} \amp -1/\sqrt{2} \\
-	      \end{bmatrix}^T
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The singular values
-	      <m>\sigma_i = \lambda_i</m>, the eigenvalues of <m>A</m>
-	      and the right singular vectors are eigenvectors of
-	      <m>A</m>. 
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
+
 
   </exercise>
 
@@ -592,6 +592,37 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>4\times 3</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>2</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      A basis for <m>\col(A)</m> is formed by the first two
+	      columns of <m>U</m>.  A basis for <m>\nul(A^T)</m> is
+	      formed by the last two columns of <m>U</m>. A basis for
+	      <m>\col(A^T)</m> is formed by the first two columns of
+	      <m>V</m>.  A basis for <m>\nul(A)</m> is formed by the
+	      last column of <m>V</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\fourvec{1.20}{0.16}{0.95}{-1.49}</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -626,37 +657,6 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>4\times 3</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>2</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      A basis for <m>\col(A)</m> is formed by the first two
-	      columns of <m>U</m>.  A basis for <m>\nul(A^T)</m> is
-	      formed by the last two columns of <m>U</m>. A basis for
-	      <m>\col(A^T)</m> is formed by the first two columns of
-	      <m>V</m>.  A basis for <m>\nul(A)</m> is formed by the
-	      last column of <m>V</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\fourvec{1.20}{0.16}{0.95}{-1.49}</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
 
   </exercise>
 
@@ -714,6 +714,54 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\Sigma = \begin{bmatrix}
+	      3 \amp 0 \amp 0 \\
+	      0 \amp \sqrt{7} \amp 0 \\
+	      0 \amp 0 \amp 0 \\
+	      \end{bmatrix}</m> and
+	      <m>V = \begin{bmatrix}
+	      2/\sqrt{6} \amp 0 \amp 1/\sqrt{3} \\
+	      1/\sqrt{6} \amp 1/\sqrt{2} \amp -1/\sqrt{3} \\
+	      -1/\sqrt{6} \amp 1/\sqrt{2} \amp 1/\sqrt{3} \\
+	      \end{bmatrix}
+	      </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\rank(A)=2</m>
+	    </p>
+	  </li>
+	  <li>
+	    <m>\uvec_1
+	    =\threevec{1/\sqrt{6}}{2/\sqrt{6}}{-1/\sqrt{6}}</m> and
+	    <m>\uvec_1
+	    =\threevec{-1/\sqrt{14}}{2/\sqrt{14}}{3/\sqrt{14}}</m>
+	  </li>
+	  <li>
+	    <p>
+	      <m>U=\begin{bmatrix}
+	      1/\sqrt{6} \amp -1/\sqrt{14} \amp 4/\sqrt{21} \\
+	      2/\sqrt{6} \amp 2/\sqrt{14} \amp -1/\sqrt{21} \\
+	      -1/\sqrt{6} \amp 3/\sqrt{14} \amp 2/\sqrt{21} \\
+	      \end{bmatrix}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The third column of <m>V</m> forms a basis for
+	      <m>\nul(A)</m> while the first two columns of <m>U</m>
+	      form a basis for <m>\col(A)</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -765,55 +813,7 @@
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\Sigma = \begin{bmatrix}
-	      3 \amp 0 \amp 0 \\
-	      0 \amp \sqrt{7} \amp 0 \\
-	      0 \amp 0 \amp 0 \\
-	      \end{bmatrix}</m> and
-	      <m>V = \begin{bmatrix}
-	      2/\sqrt{6} \amp 0 \amp 1/\sqrt{3} \\
-	      1/\sqrt{6} \amp 1/\sqrt{2} \amp -1/\sqrt{3} \\
-	      -1/\sqrt{6} \amp 1/\sqrt{2} \amp 1/\sqrt{3} \\
-	      \end{bmatrix}
-	      </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\rank(A)=2</m>
-	    </p>
-	  </li>
-	  <li>
-	    <m>\uvec_1
-	    =\threevec{1/\sqrt{6}}{2/\sqrt{6}}{-1/\sqrt{6}}</m> and 
-	    <m>\uvec_1
-	    =\threevec{-1/\sqrt{14}}{2/\sqrt{14}}{3/\sqrt{14}}</m>
-	  </li>
-	  <li>
-	    <p>
-	      <m>U=\begin{bmatrix}
-	      1/\sqrt{6} \amp -1/\sqrt{14} \amp 4/\sqrt{21} \\
-	      2/\sqrt{6} \amp 2/\sqrt{14} \amp -1/\sqrt{21} \\
-	      -1/\sqrt{6} \amp 3/\sqrt{14} \amp 2/\sqrt{21} \\
-	      \end{bmatrix}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The third column of <m>V</m> forms a basis for
-	      <m>\nul(A)</m> while the first two columns of <m>U</m>
-	      form a basis for <m>\col(A)</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
   </exercise>
 	
   <exercise>
@@ -864,6 +864,49 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      From the previous problem, we have
+	      <md>
+		U=\begin{bmatrix}
+		1/\sqrt{6} \amp 0 \amp 5/\sqrt{30} \\
+		2/\sqrt{6} \amp 1/\sqrt{5} \amp -2/\sqrt{30} \\
+		1/\sqrt{6} \amp -2/\sqrt{5} \amp -1/\sqrt{30} \\
+		\end{bmatrix},\hspace{24pt}
+		\Sigma = \begin{bmatrix}
+		\sqrt{6} \amp 0 \\
+		0 \amp \sqrt{5} \\
+		0 \amp 0 \\
+		\end{bmatrix},\hspace{24pt}
+		V = \begin{bmatrix}
+		1 \amp 0 \\
+		0 \amp -1 \\
+		\end{bmatrix}
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\rank(B)=2</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\bhat =
+	      \threevec226</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xhat =\twovec22</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -913,51 +956,8 @@
 	</ol>
       </p>
     </solution>
-		
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      From the previous problem, we have
-	      <md>
-		U=\begin{bmatrix}
-		1/\sqrt{6} \amp 0 \amp 5/\sqrt{30} \\
-		2/\sqrt{6} \amp 1/\sqrt{5} \amp -2/\sqrt{30} \\
-		1/\sqrt{6} \amp -2/\sqrt{5} \amp -1/\sqrt{30} \\
-		\end{bmatrix},\hspace{24pt}
-		\Sigma = \begin{bmatrix}
-		\sqrt{6} \amp 0 \\
-		0 \amp \sqrt{5} \\
-		0 \amp 0 \\
-		\end{bmatrix},\hspace{24pt}
-		V = \begin{bmatrix}
-		1 \amp 0 \\
-		0 \amp -1 \\
-		\end{bmatrix}
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\rank(B)=2</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\bhat = 
-	      \threevec226</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xhat =\twovec22</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 
   <exercise>
@@ -995,6 +995,34 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>A^{-1} = V\Sigma^{-1}U^T</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      All the singular values are
+	      nonzero.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      They are reciprocals of one another.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The left singular vectors of <m>A</m> are the right
+	      singular vectors of <m>A^{-1}</m> and vice versa.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1026,36 +1054,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>A^{-1} = V\Sigma^{-1}U^T</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      All the singular values are
-	      nonzero. 
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      They are reciprocals of one another.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The left singular vectors of <m>A</m> are the right
-	      singular vectors of <m>A^{-1}</m> and vice versa.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 
   <exercise>
@@ -1087,6 +1087,27 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\det(Q^TQ) = \det(Q^T)\det(Q)=\det(I) </m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>|\det(A) = |\det(U)|~|\det(\Sigma)|~|\det(V^T)|</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      All the singular values are nonzero.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1112,29 +1133,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\det(Q^TQ) = \det(Q^T)\det(Q)=\det(I) </m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>|\det(A) = |\det(U)|~|\det(\Sigma)|~|\det(V^T)|</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      All the singular values are nonzero.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 
   <exercise>
@@ -1172,6 +1172,31 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      If <m>\vvec</m> is an eigenvector of <m>G</m> with
+	      eigenvalue <m>\lambda</m>, then <m>\vvec\cdot(G\vvec) =
+	      \lambda\vvec\cdot\vvec</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      If <m>A</m> is symmetric, then <m>G=A^TA = A^2</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      If <m>\lambda</m> is an eigenvalue of <m>A</m>, then
+	      <m>\sigma^2 = \lambda^2</m> is an eigenvalue of
+	      <m>G</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1200,33 +1225,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      If <m>\vvec</m> is an eigenvector of <m>G</m> with
-	      eigenvalue <m>\lambda</m>, then <m>\vvec\cdot(G\vvec) =
-	      \lambda\vvec\cdot\vvec</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      If <m>A</m> is symmetric, then <m>G=A^TA = A^2</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      If <m>\lambda</m> is an eigenvalue of <m>A</m>, then
-	      <m>\sigma^2 = \lambda^2</m> is an eigenvalue of
-	      <m>G</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
 	    
   <exercise>
@@ -1273,6 +1273,37 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      False
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      True
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1313,39 +1344,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      False
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      True
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-    
+
+
   </exercise>
 
   <exercise>
@@ -1393,6 +1393,29 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Every column of <m>\Sigma</m> has a nonzero singular
+	      value.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Every row of <m>\Sigma</m> has a nonzero singular value.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Then <m>\Sigma</m> is a square matrix and every singular
+	      value is nonzero.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1421,31 +1444,8 @@
 	</ol>
       </p>
     </solution>
-	    
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Every column of <m>\Sigma</m> has a nonzero singular
-	      value.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Every row of <m>\Sigma</m> has a nonzero singular value.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Then <m>\Sigma</m> is a square matrix and every singular
-	      value is nonzero.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	    
+
+
   </exercise>
   
 </exercises>

--- a/src/exercises/exercises7-5.xml
+++ b/src/exercises/exercises7-5.xml
@@ -39,6 +39,41 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\rank(A) = 4</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A_1=\begin{bmatrix}
+	      1.3 \amp -1.2 \amp -1.2 \amp 3.8 \\
+	      -0.58 \amp 0.56 \amp 0.56 \amp -1.7 \\
+	      0.92 \amp -0.90 \amp -0.89 \amp 2.7 \\
+	      -0.84 \amp 0.83 \amp 0.82 \amp -2.5
+	      \end{bmatrix}</m>,
+	      <m>A_2=\begin{bmatrix}
+	      1.5 \amp -2.0 \amp -1.2 \amp 3.4 \\
+	      -1.3 \amp 2.8 \amp 0.43 \amp -0.77 \\
+	      -0.32 \amp 2.8 \amp -1.1 \amp 4.3 \\
+	      -1.3 \amp 2.1 \amp 0.75 \amp -2.0
+	      \end{bmatrix}</m>,\
+	    </p>
+	    <p>
+	      <m>A_3=\begin{bmatrix}
+	      2.2 \amp -1.9 \amp 0.048 \amp 3.7 \\
+	      -1.2 \amp 2.9 \amp 0.72 \amp -0.72 \\
+	      -0.51 \amp 2.8 \amp -1.4 \amp 4.2 \\
+	      -0.60 \amp 2.3 \amp 2.0 \amp -1.7
+	      \end{bmatrix}</m>, <m>A_4=A</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -76,41 +111,6 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\rank(A) = 4</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A_1=\begin{bmatrix}
-	      1.3 \amp -1.2 \amp -1.2 \amp 3.8 \\
-	      -0.58 \amp 0.56 \amp 0.56 \amp -1.7 \\
-	      0.92 \amp -0.90 \amp -0.89 \amp 2.7 \\
-	      -0.84 \amp 0.83 \amp 0.82 \amp -2.5
-	      \end{bmatrix}</m>,
-	      <m>A_2=\begin{bmatrix}
-	      1.5 \amp -2.0 \amp -1.2 \amp 3.4 \\
-	      -1.3 \amp 2.8 \amp 0.43 \amp -0.77 \\
-	      -0.32 \amp 2.8 \amp -1.1 \amp 4.3 \\
-	      -1.3 \amp 2.1 \amp 0.75 \amp -2.0
-	      \end{bmatrix}</m>,\
-	    </p>
-	    <p>
-	      <m>A_3=\begin{bmatrix}
-	      2.2 \amp -1.9 \amp 0.048 \amp 3.7 \\
-	      -1.2 \amp 2.9 \amp 0.72 \amp -0.72 \\
-	      -0.51 \amp 2.8 \amp -1.4 \amp 4.2 \\
-	      -0.60 \amp 2.3 \amp 2.0 \amp -1.7
-	      \end{bmatrix}</m>, <m>A_4=A</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -154,6 +154,40 @@
 
       </p>
     </statement>
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The linear system is
+	      <md>
+		\begin{bmatrix}
+		1 \amp 0 \amp 0 \\
+		1 \amp 1 \amp 1 \\
+		1 \amp 2 \amp 4 \\
+		1 \amp 3 \amp 9 \\
+		1 \amp 4 \amp 16 \\
+		\end{bmatrix}
+		\xvec
+		=
+		\fivevec10{1.5}48
+	      </md>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>U</m> is a <m>5\times5</m> matrix, <m>\Sigma</m> is
+	      <m>5\times3</m>, and <m>V</m> is <m>3\times3</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>\xhat=\threevec{0.87}{-1.34}{0.79}</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -192,41 +226,7 @@
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The linear system is
-	      <md>
-		\begin{bmatrix}
-		1 \amp 0 \amp 0 \\
-		1 \amp 1 \amp 1 \\
-		1 \amp 2 \amp 4 \\
-		1 \amp 3 \amp 9 \\
-		1 \amp 4 \amp 16 \\
-		\end{bmatrix}
-		\xvec
-		=
-		\fivevec10{1.5}48
-	      </md>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>U</m> is a <m>5\times5</m> matrix, <m>\Sigma</m> is
-	      <m>5\times3</m>, and <m>V</m> is <m>3\times3</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>\xhat=\threevec{0.87}{-1.34}{0.79}</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-		
+
   </exercise>
 
   <exercise>
@@ -265,6 +265,32 @@
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <m>\uvec~\vvec^T =
+	      \begin{bmatrix}
+	      4 \amp 0 \amp 2 \\
+	      -6 \amp 0 \amp -3
+	      \end{bmatrix}</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The rank is <m>1</m> and <m>\uvec</m> forms a basis.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This matrix projects vectors orthogonally onto the line
+	      defined by <m>\uvec</m>.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -294,34 +320,8 @@
 	</ol>
       </p>
     </solution>
-	  
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <m>\uvec~\vvec^T =
-	      \begin{bmatrix}
-	      4 \amp 0 \amp 2 \\
-	      -6 \amp 0 \amp -3
-	      \end{bmatrix}</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The rank is <m>1</m> and <m>\uvec</m> forms a basis.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This matrix projects vectors orthogonally onto the line
-	      defined by <m>\uvec</m>.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-		
+
+
   </exercise>
 	  
 	  
@@ -405,6 +405,41 @@ df.T
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The variances are
+	      <m>1.96</m>, <m>1.01</m>, <m>0.79</m>, and <m>0.24</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>74\%</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The matrix <m>B</m> is formed from the first two rows of
+	      the product <m>\Sigma V^T</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Left
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Houses on the left have larger living area, lot sizes,
+	      and prices and are newer.  Houses near the top have
+	      larger lot sizes and ages.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -458,42 +493,7 @@ df.T
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The variances are
-	      <m>1.96</m>, <m>1.01</m>, <m>0.79</m>, and <m>0.24</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>74\%</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The matrix <m>B</m> is formed from the first two rows of
-	      the product <m>\Sigma V^T</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Left
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Houses on the left have larger living area, lot sizes,
-	      and prices and are newer.  Houses near the top have
-	      larger lot sizes and ages.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
   </exercise>
 
   <exercise>
@@ -560,6 +560,41 @@ fivefour
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      For each justice, it tells us the number of times that
+	      justice voted with the majority minus the number of
+	      times they voted in the minority.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The justice that most often votes with the majority
+	      could be a swing vote.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The first five justices usually vote in the majority.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      A second justice voted with the
+	      majority 84 times more than with the minority.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Anthony Kennedy
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -607,41 +642,6 @@ fivefour
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      For each justice, it tells us the number of times that
-	      justice voted with the majority minus the number of
-	      times they voted in the minority.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The justice that most often votes with the majority
-	      could be a swing vote.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The first five justices usually vote in the majority.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      A second justice voted with the
-	      majority 84 times more than with the minority.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Anthony Kennedy
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -728,6 +728,41 @@ plot_sv(A)
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The matrix is symmetric.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>A_2</m> should be a good approximation
+	      to <m>A</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>U=V</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	     John Paul Stevens, is the least
+	      agreeable.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      The fourth and fifth justices, Anthony Kennedy and
+	      Sandra Day O'Connor are less inclined to agree with the
+	      others.
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -767,43 +802,8 @@ plot_sv(A)
 	</ol>
       </p>
     </solution>
-	      
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The matrix is symmetric.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>A_2</m> should be a good approximation
-	      to <m>A</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>U=V</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	     John Paul Stevens, is the least
-	      agreeable.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      The fourth and fifth justices, Anthony Kennedy and
-	      Sandra Day O'Connor are less inclined to agree with the
-	      others.
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	      
+
+
   </exercise>
 
   <exercise>
@@ -841,6 +841,36 @@ plot_sv(A)
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      Find the number of columns of <m>U_r^T</m> and the
+	      number of rows of <m>V_r</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      If <m>A</m> is invertible, then <m>A</m> is an
+	      <m>m\times m</m> matrix whose rank is <m>m</m>.
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>AA^{+} = (U_r\Sigma_rV_r^T)(V_r\Sigma^{-1}U_r^T) =
+	      U_rU_r^T</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>AA^{+} = (V_r\Sigma^{-1}U_r^T)(U_r\Sigma_rV_r^T)
+	      V_rV_r^T</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -880,36 +910,6 @@ plot_sv(A)
 	</ol>
       </p>
     </solution>
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      Find the number of columns of <m>U_r^T</m> and the
-	      number of rows of <m>V_r</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      If <m>A</m> is invertible, then <m>A</m> is an
-	      <m>m\times m</m> matrix whose rank is <m>m</m>.
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>AA^{+} = (U_r\Sigma_rV_r^T)(V_r\Sigma^{-1}U_r^T) =
-	      U_rU_r^T</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>AA^{+} = (V_r\Sigma^{-1}U_r^T)(U_r\Sigma_rV_r^T)
-	      V_rV_r^T</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </exercise>
 
   <exercise>
@@ -1021,6 +1021,55 @@ plot_sv(A)
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      The condition number
+	      is <m>40,000</m>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m>A^{-1}\bvec = \twovec{-14142.5}{14142.5}</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>A^{-1}\bvec = \twovec{-14142.8}{14142.8}</m>
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    <m>A^{-1}\bvec = \twovec{-14142.5}{14142.5}</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>A^{-1}\bvec = \twovec{-28284.6}{28285.3}</m>
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <m>c_2=\frac{d_2}{\sigma_2}</m>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1076,56 +1125,7 @@ plot_sv(A)
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      The condition number
-	      is <m>40,000</m>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    <m>A^{-1}\bvec = \twovec{-14142.5}{14142.5}</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>A^{-1}\bvec = \twovec{-14142.8}{14142.8}</m>
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    <m>A^{-1}\bvec = \twovec{-14142.5}{14142.5}</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>A^{-1}\bvec = \twovec{-28284.6}{28285.3}</m>
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <m>c_2=\frac{d_2}{\sigma_2}</m>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
-	  
+
   </exercise>
 
 </exercises>

--- a/src/section1-1.xml
+++ b/src/section1-1.xml
@@ -150,6 +150,11 @@
           </figure>
         </statement>
 
+        <answer>
+	  <p>
+	    There are no points that satisfy both equations.
+	  </p>
+        </answer>
         <solution>
 	  <sidebyside widths="50% 40%" margins="0%">
 	    <p>
@@ -166,11 +171,6 @@
             </image>
 	  </sidebyside>
         </solution>
-        <answer>
-	  <p>
-	    There are no points that satisfy both equations.
-	  </p>          
-        </answer>
       </task>
 
       <task label="ula-preview-1-1-c">
@@ -211,6 +211,11 @@
           </figure>
         </statement>
 
+        <answer>
+	  <p>
+	    There are infinitely many points.
+	  </p>
+        </answer>
         <solution>
 	  <sidebyside widths="50% 40%" margins="0%">
 	    <p>
@@ -225,11 +230,6 @@
             </image>
 	  </sidebyside>
         </solution>
-        <answer>
-	  <p>
-	    There are infinitely many points.
-	  </p>
-        </answer>
       </task>
 
       <task label="ula-preview-1-1-d">
@@ -275,6 +275,11 @@
           </figure>
         </statement>
 
+        <answer>
+	  <p>
+	    There are no points that satisfy all three equations.
+	  </p>
+        </answer>
         <solution>
 	  <sidebyside widths="50% 40%" margins="0%">
 	    <p>
@@ -290,11 +295,6 @@
             </image>
           </sidebyside>
         </solution>
-        <answer>
-	  <p>
-	    There are no points that satisfy all three equations.
-	  </p>
-        </answer>
       </task>
 
     </activity>
@@ -682,6 +682,17 @@
 
       </ol></p>
       </statement>
+      <answer>
+	<p><ol marker="a.">
+	  <li> <p> Yes. </p></li>
+	  <li> <p> No. </p></li>
+	  <li> <p> Yes. </p></li>
+	  <li> <p> We would expect there to be no solutions. </p></li>
+	  <li> <p> We would expect there to be no solutions. </p></li>
+	  <li> <p> We would expect there to be infinitely many
+	  solutions. </p></li>
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li>
@@ -732,18 +743,7 @@
 	</ol></p>
       </solution>
 
-      <answer>
-	<p><ol marker="a.">
-	  <li> <p> Yes. </p></li>
-	  <li> <p> No. </p></li>
-	  <li> <p> Yes. </p></li>
-	  <li> <p> We would expect there to be no solutions. </p></li>
-	  <li> <p> We would expect there to be no solutions. </p></li>
-	  <li> <p> We would expect there to be infinitely many
-	  solutions. </p></li>
-	</ol></p>
-      </answer>
-	  
+
     </activity>
 
   </subsection>
@@ -895,6 +895,32 @@
       </p>
       </statement>
 
+      <answer>
+	<p><ol marker="a.">
+	  <li><p> There are two linear equations in this list.
+	    <ol marker="1.">
+	      <li><p> This is not a linear equation. </p></li>
+	      <li><p> This is a linear equation. </p></li>
+	      <li><p> This is a linear equation. </p></li>
+	    </ol>
+	  </p>
+	  </li>
+
+	  <li><p> We will see that the system of linear equations has
+	  infinitely many solutions.
+	    <ol marker="1.">
+	      <li><p> This is a solution. </p></li>
+	      <li><p> This is a not solution. </p></li>
+	      <li><p> This is a not solution. </p></li>
+	      <li><p> Yes, <m>(x,y,z) = (3,0,-2)</m> is a
+	      solution. </p></li>
+	      <li><p> Yes, because there should be infinitely many
+	      solutions. </p></li>
+	    </ol>
+	  </p></li>
+	</ol>
+	</p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li><p> There are two linear equations in this list.
@@ -958,33 +984,7 @@
 	</ol>
 	</p>
       </solution>
-      
-      <answer>
-	<p><ol marker="a.">
-	  <li><p> There are two linear equations in this list.
-	    <ol marker="1.">
-	      <li><p> This is not a linear equation. </p></li>
-	      <li><p> This is a linear equation. </p></li>
-	      <li><p> This is a linear equation. </p></li>
-	    </ol>
-	  </p>
-	  </li>
 
-	  <li><p> We will see that the system of linear equations has
-	  infinitely many solutions. 
-	    <ol marker="1.">
-	      <li><p> This is a solution. </p></li>
-	      <li><p> This is a not solution. </p></li>
-	      <li><p> This is a not solution. </p></li>
-	      <li><p> Yes, <m>(x,y,z) = (3,0,-2)</m> is a
-	      solution. </p></li>
-	      <li><p> Yes, because there should be infinitely many
-	      solutions. </p></li>
-	    </ol>
-	  </p></li>
-	</ol>
-	</p>
-      </answer>
 
     </activity>
 

--- a/src/section1-2.xml
+++ b/src/section1-2.xml
@@ -49,15 +49,15 @@
           </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p> <m>(x,y) = (2,-1)</m>. </p>
+        </answer>
         <solution>
 	  <p>
 	    The equations tell us the value of both variables so
 	    there is only one solution  <m>(x,y) = (2,-1)</m>.
 	  </p>
         </solution>
-        <answer>
-          <p> <m>(x,y) = (2,-1)</m>. </p>
-        </answer>
       </task>
 
       <task label="ula-preview-1-2-b">
@@ -75,6 +75,9 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p> <m>(x,y,z) = (-1,-1,2)</m>. </p>
+        </answer>
         <solution>
 	  <p>
 	    We first use the third equation to determine that
@@ -93,9 +96,6 @@
 	    (-1,-1,2)</m>.
 	  </p>
         </solution>
-        <answer>
-          <p> <m>(x,y,z) = (-1,-1,2)</m>. </p>
-        </answer>
       </task>
 
       <task label="ula-preview-1-2-c">
@@ -111,6 +111,9 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p> <m>(x,y) = (2,-1)</m>. </p>
+        </answer>
         <solution>
 	  <p>
 	    Notice that we can rewrite the first equation as
@@ -124,9 +127,6 @@
 	    <m>(x,y) = (2,-1)</m>.
 	  </p>
         </solution>
-        <answer>
-          <p> <m>(x,y) = (2,-1)</m>. </p>
-        </answer>
       </task>
 
       <task label="ula-preview-1-2-d">
@@ -135,6 +135,9 @@
 	  0</m>.</p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p> Any real number is a solution. </p>
+        </answer>
         <solution>
 	  <p>
 	    No matter the value of <m>x</m>, we have <m>0x = 0</m>.
@@ -144,9 +147,6 @@
 	    value of <m>x</m>.
 	  </p>
         </solution>
-        <answer>
-          <p> Any real number is a solution. </p>
-        </answer>
       </task>
 
       <task label="ula-preview-1-2-e">
@@ -155,15 +155,15 @@
 	  5</m>.</p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p> There are no solutions. </p>
+        </answer>
         <solution>
 	  <p> By contrast, the equation <m>0x=5</m> has no solutions
 	  since no value of <m>x</m>, when multiplied by <m>0</m>,
 	  can produce <m>5</m>.
 	  </p>
         </solution>
-        <answer>
-          <p> There are no solutions. </p>
-        </answer>
       </task>
 
       <task component="rs-preview"
@@ -621,6 +621,16 @@
       </ol></p>
       </statement>
 
+      <answer>
+	<p><ol marker="a.">
+	  <li><p> There is a single solution
+	  <m>(1,2,-1)</m>. </p></li>
+
+	  <li><p> There are infinitely many solutions. </p></li>
+
+	  <li><p> There are no solutions. </p></li>
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li>
@@ -736,16 +746,6 @@
 	</ol></p>
       </solution>
 
-      <answer>
-	<p><ol marker="a.">
-	  <li><p> There is a single solution
-	  <m>(1,2,-1)</m>. </p></li>
-
-	  <li><p> There are infinitely many solutions. </p></li>
-
-	  <li><p> There are no solutions. </p></li>
-	</ol></p>
-      </answer>
 
     </activity>
   </subsection>
@@ -948,6 +948,20 @@
 	</ol></p>
       </statement>
 
+      <answer>
+	<p><ol marker="a.">
+	  <li><p> There is a single solution
+	  <m>(3,-1,0)</m>. </p></li>
+
+	  <li><p> There is a single solution <m>(3,0)</m>. </p></li>
+
+	  <li><p> There are no solutions. </p></li>
+
+	  <li><p> This system has three equations in five variables,
+	  and there are infinitely many solutions. </p></li>
+
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li><p> The augmented matrix for this linear system is
@@ -1029,21 +1043,7 @@
 	</ol></p>
       </solution>
 
-      <answer>
-	<p><ol marker="a.">
-	  <li><p> There is a single solution
-	  <m>(3,-1,0)</m>. </p></li>
 
-	  <li><p> There is a single solution <m>(3,0)</m>. </p></li>
-
-	  <li><p> There are no solutions. </p></li>
-
-	  <li><p> This system has three equations in five variables,
-	  and there are infinitely many solutions. </p></li>
-
-	</ol></p>
-      </answer>
-	    
     </activity>
 
   </subsection>
@@ -1181,6 +1181,56 @@
       </p>
       </statement>
 
+      <answer>
+	<p><ol marker="a.">
+	  <li><p> The row equivalent reduced row echelon form is
+	  <md>
+	    \left[
+	    \begin{array}{rrr|r}
+	    1 \amp 0 \amp 2 \amp -4 \\
+	    0 \amp 1 \amp 3 \amp 2 \\
+	    \end{array}
+	    \right],
+	  </md>
+	  and there are infinitely many solutions.
+	  </p></li>
+
+	  <li> <p> This matrix is in reduced row echelon form.  There is
+	  a single solution <m>(-1,3,1)</m>.
+	  </p></li>
+
+	  <li> <p> This matrix is also in reduced row echelon form.
+	  However, this are no solutions since the third equation is
+	  <m>0 = 1</m>.
+	  </p></li>
+
+	  <li><p> The row equivalent reduced row echelon form is
+	  <md>
+	    \left[
+	    \begin{array}{rrr|r}
+	    1 \amp 0 \amp 4 \amp 2 \\
+	    0 \amp 1 \amp 3 \amp 2 \\
+	    0 \amp 0 \amp 0 \amp 0 \\
+	    \end{array}
+	    \right].
+	  </md>
+	  There are infinitely many solutions.
+	  </p></li>
+
+	  <li><p> The row equivalent reduced row echelon form is
+	  <md>
+	    \left[
+	    \begin{array}{rrr|r}
+	    1 \amp 0 \amp 0 \amp -1 \\
+	    0 \amp 1 \amp 0 \amp 2 \\
+	    0 \amp 0 \amp 1 \amp 1 \\
+	    \end{array}
+	    \right].
+	  </md>
+	  This system has the single solution <m>(-1,2,1)</m>.
+	  </p></li>
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	<li> <p> Because the leading entry in the first row is not a
@@ -1280,57 +1330,7 @@
       </ol></p>
       </solution>
 
-      <answer>
-	<p><ol marker="a.">
-	  <li><p> The row equivalent reduced row echelon form is
-	  <md>
-	    \left[
-	    \begin{array}{rrr|r}
-	    1 \amp 0 \amp 2 \amp -4 \\
-	    0 \amp 1 \amp 3 \amp 2 \\
-	    \end{array}
-	    \right],
-	  </md>
-	  and there are infinitely many solutions.
-	  </p></li>
 
-	  <li> <p> This matrix is in reduced row echelon form.  There is
-	  a single solution <m>(-1,3,1)</m>.
-	  </p></li>
-	  
-	  <li> <p> This matrix is also in reduced row echelon form.
-	  However, this are no solutions since the third equation is
-	  <m>0 = 1</m>.
-	  </p></li>
-
-	  <li><p> The row equivalent reduced row echelon form is
-	  <md>
-	    \left[
-	    \begin{array}{rrr|r}
-	    1 \amp 0 \amp 4 \amp 2 \\
-	    0 \amp 1 \amp 3 \amp 2 \\
-	    0 \amp 0 \amp 0 \amp 0 \\
-	    \end{array}
-	    \right].
-	  </md>
-	  There are infinitely many solutions.
-	  </p></li>
-
-	  <li><p> The row equivalent reduced row echelon form is
-	  <md>
-	    \left[
-	    \begin{array}{rrr|r}
-	    1 \amp 0 \amp 0 \amp -1 \\
-	    0 \amp 1 \amp 0 \amp 2 \\
-	    0 \amp 0 \amp 1 \amp 1 \\
-	    \end{array}
-	    \right].
-	  </md>
-	  This system has the single solution <m>(-1,2,1)</m>.
-	  </p></li>
-	</ol></p>
-      </answer>
-	    
     </activity>
 
     <p>

--- a/src/section1-3.xml
+++ b/src/section1-3.xml
@@ -172,39 +172,6 @@ for i in range(10):
 	  </ol>
 	</p>
       </statement>
-      <solution>
-        <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <cd>
-3 + 4*(2^4 - 1)
-	      </cd>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      Only the results of the last line are displayed.
-	    </p>
-	  </li>
-
-	  <li>
-	    <p>
-	      <cd>
-total = 90 + 100 + 98
-average = total / 3
-print(average)
-	      </cd>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      This cells print the integers from 0 to 9.
-	    </p>
-	  </li>
-	</ol>
-        </p>
-      </solution>
       <answer>
         <p>
 	<ol marker="a.">
@@ -238,6 +205,39 @@ print(average)
 	</ol>
         </p>
       </answer>
+      <solution>
+        <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <cd>
+3 + 4*(2^4 - 1)
+	      </cd>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      Only the results of the last line are displayed.
+	    </p>
+	  </li>
+
+	  <li>
+	    <p>
+	      <cd>
+total = 90 + 100 + 98
+average = total / 3
+print(average)
+	      </cd>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      This cells print the integers from 0 to 9.
+	    </p>
+	  </li>
+	</ol>
+        </p>
+      </solution>
 
     </activity>
   </subsection>
@@ -468,6 +468,61 @@ A.rref()
 	  </ol>
 	</p>
       </statement>
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<cd>
+matrix(3, 4, [-1,-2, 2,-1,
+               2, 4,-1, 5,
+               1, 2, 0, 3])
+		</cd>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The reduced row echelon form of the matrix is
+		<md>
+		  \begin{bmatrix}
+		  1 \amp 2 \amp 0 \amp 3 \\
+		  0 \amp 0 \amp 1 \amp 1 \\
+		  0 \amp 0 \amp 0 \amp 0
+		  \end{bmatrix}.
+		</md>
+	      </p>
+	    </li>
+
+	    <li>
+	      <p>
+		There is a unique solution <m>(x_1,x_2,x_3,x_4) =
+		(-2,-1,0,3)</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The first four columns of the reduced row echelon form
+		of <m>B</m> form the reduced row echelon form of
+		<m>A</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The reduced row echelon form of the coefficient matrix
+		is
+		<md>
+		  \begin{bmatrix}
+		  1 \amp 0 \amp 0 \amp 0 \\
+		  0 \amp 1 \amp 0 \amp 0 \\
+		  0 \amp 0 \amp 1 \amp 0 \\
+		  0 \amp 0 \amp 0 \amp 1 \\
+		  \end{bmatrix}.
+		</md>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -533,61 +588,6 @@ matrix(3, 4, [-1,-2, 2,-1,
 	  </ol>
 	</p>
       </solution>
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<cd>
-matrix(3, 4, [-1,-2, 2,-1,
-               2, 4,-1, 5,
-               1, 2, 0, 3])
-		</cd>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The reduced row echelon form of the matrix is
-		<md>
-		  \begin{bmatrix}
-		  1 \amp 2 \amp 0 \amp 3 \\
-		  0 \amp 0 \amp 1 \amp 1 \\
-		  0 \amp 0 \amp 0 \amp 0
-		  \end{bmatrix}.
-		</md>
-	      </p>
-	    </li>
-
-	    <li>
-	      <p>
-		There is a unique solution <m>(x_1,x_2,x_3,x_4) =
-		(-2,-1,0,3)</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The first four columns of the reduced row echelon form
-		of <m>B</m> form the reduced row echelon form of
-		<m>A</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The reduced row echelon form of the coefficient matrix
-		is 
-		<md>
-		  \begin{bmatrix}
-		  1 \amp 0 \amp 0 \amp 0 \\
-		  0 \amp 1 \amp 0 \amp 0 \\
-		  0 \amp 0 \amp 1 \amp 0 \\
-		  0 \amp 0 \amp 0 \amp 1 \\
-		  \end{bmatrix}.
-		</md>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <assemblage>

--- a/src/section1-4.xml
+++ b/src/section1-4.xml
@@ -77,28 +77,6 @@
 	  </p>
         </statement>
         <response componet="rs-preview"/>
-        <solution>
-          <p>
-	    The pivot positions are indicated below
-	    <md>
-	      \left[
-	      \begin{array}{rrrr}
-	      {\mathbf 2} \amp 4 \amp 6 \amp -1 \\
-	      -3 \amp {\mathbf 1} \amp 5 \amp 0 \\
-	      1 \amp 3 \amp 5 \amp {\mathbf 1} \\
-	      \end{array}
-	      \right]
-	      \sim
-	      \left[
-	      \begin{array}{rrrr}
-	      {\mathbf 1} \amp 0 \amp -1 \amp 0 \\
-	      0 \amp {\mathbf 1} \amp 2 \amp 0 \\
-	      0 \amp 0 \amp 0 \amp {\mathbf 1} \\
-	      \end{array}
-	      \right]\text{.}
-	    </md>
-	  </p>
-        </solution>
         <answer>
           <p>
 	    The pivot positions are indicated below
@@ -121,6 +99,28 @@
 	    </md>
 	  </p>
         </answer>
+        <solution>
+          <p>
+	    The pivot positions are indicated below
+	    <md>
+	      \left[
+	      \begin{array}{rrrr}
+	      {\mathbf 2} \amp 4 \amp 6 \amp -1 \\
+	      -3 \amp {\mathbf 1} \amp 5 \amp 0 \\
+	      1 \amp 3 \amp 5 \amp {\mathbf 1} \\
+	      \end{array}
+	      \right]
+	      \sim
+	      \left[
+	      \begin{array}{rrrr}
+	      {\mathbf 1} \amp 0 \amp -1 \amp 0 \\
+	      0 \amp {\mathbf 1} \amp 2 \amp 0 \\
+	      0 \amp 0 \amp 0 \amp {\mathbf 1} \\
+	      \end{array}
+	      \right]\text{.}
+	    </md>
+	  </p>
+        </solution>
       </task>
 
       <task label="ula-preview-1-4-b">
@@ -133,6 +133,11 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p>
+	    Three.
+	  </p>
+        </answer>
         <solution>
           <p>
 	    A row contains at most one pivot position.  Therefore, a
@@ -147,11 +152,6 @@
 	    </md>
 	  </p>
         </solution>
-        <answer>
-          <p>
-	    Three.
-	  </p>
-        </answer>
       </task>
 
       <task label="ula-preview-1-4-c">
@@ -163,6 +163,11 @@
 	  largest possible number of pivot positions. </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p>
+	    Three.
+	  </p>
+        </answer>
         <solution>
           <p>
 	    A column contains at most one pivot position.
@@ -180,11 +185,6 @@
 	    </md>
 	  </p>
         </solution>
-        <answer>
-          <p>
-	    Three.
-	  </p>
-        </answer>
       </task>
 
       <task label="ula-preview-1-4-d">
@@ -194,6 +194,13 @@
 	  such a matrix? </p>
         </statement>
         <response componet="rs-preview"/>
+        <answer>
+          <p>
+	    Such a matrix must necessarily have the same number of
+	    rows and columns, which means it is what we call a
+	    square matrix.
+	  </p>
+        </answer>
         <solution>
           <p>
 	    A matrix with a pivot position in every row and every
@@ -211,13 +218,6 @@
 	    square matrix.
 	  </p>
         </solution>
-        <answer>
-          <p>
-	    Such a matrix must necessarily have the same number of
-	    rows and columns, which means it is what we call a
-	    square matrix.
-	  </p>
-        </answer>
       </task>
 
        <task component="rs-preview">

--- a/src/section2-1.xml
+++ b/src/section2-1.xml
@@ -690,6 +690,34 @@
       </p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li><p> The linear combinations lie on the line defined by
+	    <m>\vvec</m>.
+	    </p></li>
+
+	    <li><p> <m>\twovec{0}{-3}</m>. </p></li>
+
+	    <li><p> They lie on the line through <m>\wvec</m> parallel
+	    to <m>\vvec</m>.
+	    </p></li>
+
+	    <li><p> Yes, with weights <m>c=d=0</m>. </p></li>
+
+	    <li><p> Yes, with weights <m>c=2</m> and
+	    <m>d=-1</m>. </p></li>
+
+	    <li><p> This can be done by writing the appropriate linear
+	    system for the weights.
+	    </p></li>
+
+	    <li><p> No, any two-dimensional vector can be expressed
+	    as a linear combination of <m>\vvec</m> and <m>\wvec</m>.
+	    </p></li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -767,34 +795,6 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li><p> The linear combinations lie on the line defined by
-	    <m>\vvec</m>.
-	    </p></li>
-
-	    <li><p> <m>\twovec{0}{-3}</m>. </p></li>
-
-	    <li><p> They lie on the line through <m>\wvec</m> parallel
-	    to <m>\vvec</m>.
-	    </p></li>
-
-	    <li><p> Yes, with weights <m>c=d=0</m>. </p></li>
-
-	    <li><p> Yes, with weights <m>c=2</m> and
-	    <m>d=-1</m>. </p></li>
-
-	    <li><p> This can be done by writing the appropriate linear
-	    system for the weights.
-	    </p></li>
-
-	    <li><p> No, any two-dimensional vector can be expressed
-	    as a linear combination of <m>\vvec</m> and <m>\wvec</m>.
-	    </p></li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <p> This activity illustrates how linear combinations are
@@ -1056,6 +1056,49 @@
       </p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li><p>
+	      The vector <m>\bvec</m> cannot be expressed as a linear
+	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
+	      and <m>\vvec_3</m>.
+	    </p></li>
+
+	    <li><p>
+	      We find vectors
+	      <md>
+		\vvec_1=\threevec{3}{1}{-1},
+		\vvec_2=\threevec{2}{0}{-1},
+		\vvec_3=\threevec{-1}{2}{3},
+		\bvec=\threevec{4}{0}{1}\text{.}
+	      </md>
+	    </p></li>
+
+	    <li><p>
+	      Yes, <m>\bvec</m> can be expressed as a linear
+	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
+	      and <m>\vvec_3</m> in infinitely many ways.
+	    </p></li>
+
+	    <li><p>
+	      No.
+	    </p></li>
+
+	    <li><p>
+	      Yes, <m>\bvec</m> can be expressed as a linear
+	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
+	      and <m>\vvec_3</m> in exactly one way.
+	    </p></li>
+
+	    <li><p>
+	      Any vector <m>\bvec</m> can be expressed as a linear
+	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
+	      and <m>\vvec_3</m> in exactly one way.
+	    </p></li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1173,49 +1216,6 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li><p>
-	      The vector <m>\bvec</m> cannot be expressed as a linear
-	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
-	      and <m>\vvec_3</m>.
-	    </p></li>
-
-	    <li><p>
-	      We find vectors
-	      <md>
-		\vvec_1=\threevec{3}{1}{-1},
-		\vvec_2=\threevec{2}{0}{-1},
-		\vvec_3=\threevec{-1}{2}{3},
-		\bvec=\threevec{4}{0}{1}\text{.}
-	      </md>
-	    </p></li>
-
-	    <li><p>
-	      Yes, <m>\bvec</m> can be expressed as a linear
-	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
-	      and <m>\vvec_3</m> in infinitely many ways.
-	    </p></li>
-
-	    <li><p>
-	      No.
-	    </p></li>
-
-	    <li><p>
-	      Yes, <m>\bvec</m> can be expressed as a linear
-	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
-	      and <m>\vvec_3</m> in exactly one way.
-	    </p></li>
-
-	    <li><p>
-	      Any vector <m>\bvec</m> can be expressed as a linear
-	      combination of <m>\vvec_1</m>, <m>\vvec_2</m>,
-	      and <m>\vvec_3</m> in exactly one way.
-	    </p></li>
-	  </ol>
-	</p>
-      </answer>
 
     </activity>
 

--- a/src/section2-2.xml
+++ b/src/section2-2.xml
@@ -128,15 +128,6 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    <m>\left[\begin{array}{rrr}
-	    -9 \amp -3 \amp 0 \\
-	    12 \amp -9 \amp 3 \\
-	    \end{array}\right]
-	    </m>
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    <m>\left[\begin{array}{rrr}
@@ -146,6 +137,15 @@
 	    </m>
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    <m>\left[\begin{array}{rrr}
+	    -9 \amp -3 \amp 0 \\
+	    12 \amp -9 \amp 3 \\
+	    \end{array}\right]
+	    </m>
+	  </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-2-b">
@@ -171,16 +171,6 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    <m>\left[\begin{array}{rr}
-	    4 \amp -4 \\
-	    -1 \amp 0 \\
-	    4 \amp 5 \\
-	    \end{array}\right]
-	    </m>
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    <m>\left[\begin{array}{rr}
@@ -191,6 +181,16 @@
 	    </m>
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    <m>\left[\begin{array}{rr}
+	    4 \amp -4 \\
+	    -1 \amp 0 \\
+	    4 \amp 5 \\
+	    \end{array}\right]
+	    </m>
+	  </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-2-c">
@@ -200,16 +200,16 @@
 	  form the sum <m>A+B</m>? </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    The shapes must be the same.
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    The shapes must be the same.
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    The shapes must be the same.
+	  </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-2-d">
@@ -235,16 +235,16 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    The shape of <m>A</m> must be <m>n\times n</m>.
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    The shape of <m>A</m> must be <m>n\times n</m>.
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    The shape of <m>A</m> must be <m>n\times n</m>.
+	  </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-2-e">
@@ -264,17 +264,6 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    <m>
-	      A-2I_3 = \left[\begin{array}{rrr}
-	      -1 \amp 2 \amp -2 \\
-	      2 \amp -5 \amp 3 \\
-	      -2 \amp 3 \amp 2 \\
-	      \end{array}\right]
-	    </m>
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    <m>
@@ -286,6 +275,17 @@
 	    </m>
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    <m>
+	      A-2I_3 = \left[\begin{array}{rrr}
+	      -1 \amp 2 \amp -2 \\
+	      2 \amp -5 \amp 3 \\
+	      -2 \amp 3 \amp 2 \\
+	      \end{array}\right]
+	    </m>
+	  </p>
+        </solution>
       </task>
 
       <task component="rs-preview">
@@ -529,6 +529,33 @@
       </ol>
       </p></statement>
 
+      <answer>
+	<p><ol marker="a.">
+	  <li><p>
+	    <m>\threevec{4}{11}{9}\text{.}
+	    </m>
+	  </p></li>
+
+	  <li><p>
+	    The dimension of <m>\xvec</m> must three, and the
+	    dimension of <m>A\xvec</m> must be four.
+	  </p></li>
+
+	  <li><p> <m>A\zerovec = \zerovec</m>. </p></li>
+
+	  <li><p> <m>I\xvec = \xvec</m>. </p></li>
+
+	  <li><p>
+	    <m> A\evec_1 = 1\vvec_1+0\vvec_2+\ldots+0\vvec_n =
+	    \vvec_1</m>.
+	  </p></li>
+
+	  <li><p>
+	    <m>\xvec=\twovec{2}{2}</m> is the unique
+	    solution.
+	  </p></li>
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li><p>
@@ -596,35 +623,8 @@
 	  </p></li>
 	</ol></p>
       </solution>
-	  
-      <answer>
-	<p><ol marker="a.">
-	  <li><p>
-	    <m>\threevec{4}{11}{9}\text{.}
-	    </m>
-	  </p></li>
 
-	  <li><p>
-	    The dimension of <m>\xvec</m> must three, and the
-	    dimension of <m>A\xvec</m> must be four.
-	  </p></li>
 
-	  <li><p> <m>A\zerovec = \zerovec</m>. </p></li>
-
-	  <li><p> <m>I\xvec = \xvec</m>. </p></li>
-
-	  <li><p>
-	    <m> A\evec_1 = 1\vvec_1+0\vvec_2+\ldots+0\vvec_n =
-	    \vvec_1</m>.
-	  </p></li>
-
-	  <li><p>
-	    <m>\xvec=\twovec{2}{2}</m> is the unique
-	    solution.
-	  </p></li>
-	</ol></p>
-      </answer>
-	  
     </activity>
 
     <p>
@@ -747,6 +747,41 @@
       </p>
       </statement>
 
+      <answer>
+	<p><ol marker="a.">
+	  <li><p> We define
+	    <cd>
+A = matrix(3, 4, [1, 2, 0, -1,
+                  2, 4, -3, -2,
+                  -1, -2, 6, 1])
+v = vector([3, 1, -1, 1])
+A*v
+	    </cd>
+	  </p></li>
+
+	  <li><p> We define
+	    <cd>
+A = matrix(2, 3, [-2, 0, 3, 1, 4, 2])
+zero = vector([0, 0])
+v = vector([-2, 3])
+w = vector([1, 2])
+	    </cd>
+	  </p></li>
+
+	  <li><p>
+	    <m>A\zerovec = \zerovec</m>.
+	  </p></li>
+
+	  <li><p>
+	    <m>A(3\vvec) = 3(A\vvec)</m>.
+	  </p></li>
+
+	  <li><p>
+	    <m>A(\vvec+\wvec) = A\vvec + A\wvec</m>
+	  </p></li>
+
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li><p> We define
@@ -782,43 +817,8 @@ w = vector([1, 2])
 
 	</ol></p>
       </solution>
-	    
-      <answer>
-	<p><ol marker="a.">
-	  <li><p> We define
-	    <cd>
-A = matrix(3, 4, [1, 2, 0, -1,
-                  2, 4, -3, -2,
-                  -1, -2, 6, 1])
-v = vector([3, 1, -1, 1])
-A*v		  
-	    </cd>
-	  </p></li>
 
-	  <li><p> We define
-	    <cd>
-A = matrix(2, 3, [-2, 0, 3, 1, 4, 2])
-zero = vector([0, 0])
-v = vector([-2, 3])
-w = vector([1, 2])
-	    </cd>
-	  </p></li>
 
-	  <li><p>
-	    <m>A\zerovec = \zerovec</m>.
-	  </p></li>
-
-	  <li><p>
-	    <m>A(3\vvec) = 3(A\vvec)</m>.
-	  </p></li>
-
-	  <li><p>
-	    <m>A(\vvec+\wvec) = A\vvec + A\wvec</m>
-	  </p></li>
-
-	</ol></p>
-      </answer>
-	    
     </activity>
 
     <p>
@@ -1118,6 +1118,36 @@ w = vector([1, 2])
       </ol>
       </p></statement>
 
+      <answer>
+	<p><ol marker="a.">
+	  <li><p>
+	    <m>A = \left[\begin{array}{rrr}
+	    2 \amp 1 \amp -3 \\
+	    -1 \amp 2 \amp 1 \\
+	    3 \amp -1 \amp 0 \\
+	    \end{array}\right]
+	    </m>
+	    and <m>\bvec=\threevec{4}{3}{-4}</m>.
+	  </p></li>
+
+	  <li><p>
+	    <m>
+	      \xvec = \threevec{x_1}{x_2}{x_3} =
+	      \threevec{-1}{3}{0}+x_3\threevec{3}{9}{1}\text{.}
+	    </m>
+	  </p></li>
+
+	  <li><p>
+	    There are no solutions.
+	  </p></li>
+
+	  <li><p>
+	    There is at least one solution, namely,
+	    <m>\xvec=\zerovec</m>.
+	  </p></li>
+
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li><p>
@@ -1178,36 +1208,6 @@ w = vector([1, 2])
 	</ol></p>
       </solution>
 
-      <answer>
-	<p><ol marker="a.">
-	  <li><p>
-	    <m>A = \left[\begin{array}{rrr}
-	    2 \amp 1 \amp -3 \\
-	    -1 \amp 2 \amp 1 \\
-	    3 \amp -1 \amp 0 \\
-	    \end{array}\right]
-	    </m>
-	    and <m>\bvec=\threevec{4}{3}{-4}</m>.
-	  </p></li>
-
-	  <li><p>
-	    <m>
-	      \xvec = \threevec{x_1}{x_2}{x_3} =
-	      \threevec{-1}{3}{0}+x_3\threevec{3}{9}{1}\text{.}
-	    </m>
-	  </p></li>
-
-	  <li><p>
-	    There are no solutions.
-	  </p></li>
-
-	  <li><p>
-	    There is at least one solution, namely,
-	    <m>\xvec=\zerovec</m>.
-	  </p></li>
-
-	</ol></p>
-      </answer>
 
     </activity>
   </subsection>
@@ -1410,6 +1410,53 @@ w = vector([1, 2])
       </p>
       </statement>
       
+      <answer>
+	<p><ol marker="a.">
+	  <li><p>
+	    The product <m>AB</m> exists because the number of columns
+	    of <m>A</m> equals the number of rows of <m>B</m>.  The
+	    dimensions of <m>AB</m> are <m>2\times 2</m>.
+	  </p></li>
+
+	  <li><p>
+	    We have
+	    <m>AB =
+	    \left[\begin{array}{rr}
+	    2 \amp 4 \\
+	    -3 \amp 9
+	    \end{array}\right]
+	    </m>.
+	  </p></li>
+
+	  <li><p> Define
+	    <cd>
+A = matrix(2, 3, [1, 3, 2, -3, 4, -1])
+B = matrix(3, 2, [3, 0, 1, 2, -2, -1])
+A*B
+	    </cd>
+	  </p></li>
+
+	  <li><p>
+	    It is not generally true that <m>AB=BA</m>.
+	  </p></li>
+
+	  <li><p> We find that <m>A(B+C)=AB + AC</m>.
+	  </p></li>
+
+	  <li><p> We find that <m>A(BC) = (AB)C</m>.
+	  </p></li>
+
+	  <li><p>
+	    It is not generally true that <m>B=C</m> if <m>AB=AC</m>.
+	  </p></li>
+
+	  <li><p>
+	    It is not generally true that <m>A=0</m> or <m>B=0</m> if
+	    <m>AB=0</m>.
+	  </p></li>
+
+	</ol></p>
+      </answer>
       <solution>
 	<p><ol marker="a.">
 	  <li><p>
@@ -1462,53 +1509,6 @@ A*B
 	</ol></p>
       </solution>
 
-      <answer>
-	<p><ol marker="a.">
-	  <li><p>
-	    The product <m>AB</m> exists because the number of columns
-	    of <m>A</m> equals the number of rows of <m>B</m>.  The
-	    dimensions of <m>AB</m> are <m>2\times 2</m>.
-	  </p></li>
-
-	  <li><p>
-	    We have
-	    <m>AB =
-	    \left[\begin{array}{rr}
-	    2 \amp 4 \\
-	    -3 \amp 9
-	    \end{array}\right]
-	    </m>.
-	  </p></li>
-
-	  <li><p> Define
-	    <cd>
-A = matrix(2, 3, [1, 3, 2, -3, 4, -1])
-B = matrix(3, 2, [3, 0, 1, 2, -2, -1])
-A*B
-	    </cd>
-	  </p></li>
-
-	  <li><p>
-	    It is not generally true that <m>AB=BA</m>.
-	  </p></li>
-
-	  <li><p> We find that <m>A(B+C)=AB + AC</m>.
-	  </p></li>
-
-	  <li><p> We find that <m>A(BC) = (AB)C</m>.
-	  </p></li>
-
-	  <li><p>
-	    It is not generally true that <m>B=C</m> if <m>AB=AC</m>.
-	  </p></li>
-
-	  <li><p>
-	    It is not generally true that <m>A=0</m> or <m>B=0</m> if
-	    <m>AB=0</m>.
-	  </p></li>
-
-	</ol></p>
-      </answer>
 
       
     </activity>

--- a/src/section2-3.xml
+++ b/src/section2-3.xml
@@ -49,16 +49,16 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p> We know there must be a pivot position in the rightmost
-	  column of the augmented matrix.
-	  </p>
-        </solution>
         <answer>
 	  <p> We know there must be a pivot position in the rightmost
 	  column of the augmented matrix.
 	  </p>
         </answer>
+        <solution>
+	  <p> We know there must be a pivot position in the rightmost
+	  column of the augmented matrix.
+	  </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-3-b">
@@ -82,6 +82,9 @@
 	  </sage>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p><m>\xvec=\threevec{2}{3}{0}+x_3\threevec{2}{1}{1}</m></p>
+        </answer>
         <solution>
 	  <p>
 	    We construct the augmented matrix
@@ -105,9 +108,6 @@
 	    </md>.
 	  </p>
         </solution>
-        <answer>
-          <p><m>\xvec=\threevec{2}{3}{0}+x_3\threevec{2}{1}{1}</m></p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-3-c">
@@ -120,6 +120,9 @@
 	  </sage>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p>The equation <m>A\xvec=\bvec</m> is inconsistent.</p>
+        </answer>
         <solution>
 	  <p>
 	    Now the augmented matrix is
@@ -140,9 +143,6 @@
 	    inconsistent.
 	  </p>
         </solution>
-        <answer>
-          <p>The equation <m>A\xvec=\bvec</m> is inconsistent.</p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-3-d">
@@ -150,6 +150,9 @@
 	  <p> Identify the pivot positions of <m>A</m>. </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p>There are two pivot positions.</p>
+        </answer>
         <solution>
 	  <p>
 	    There are two pivot positions in <m>A</m>, as shown.
@@ -168,9 +171,6 @@
 	    </md>
 	  </p>
         </solution>
-        <answer>
-          <p>There are two pivot positions.</p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-3-e">
@@ -181,6 +181,9 @@
 	  matrix <m>A</m> tells us to expect this? </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p>There is a row of <m>A</m> without a pivot position.</p>
+        </answer>
         <solution>
 	  <p>
 	    Since there is a row of <m>A</m> that does not have a
@@ -190,9 +193,6 @@
 	    case, we have an inconsistent system.
 	  </p>
         </solution>
-        <answer>
-          <p>There is a row of <m>A</m> without a pivot position.</p>
-        </answer>
       </task>
 
       <task component="rs-preview">

--- a/src/section2-4.xml
+++ b/src/section2-4.xml
@@ -56,6 +56,9 @@
 	  </sage>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p><m>\laspan{\vvec_1,\vvec_2,\vvec_3} = \real^3</m>.</p>
+        </answer>
         <solution>
 	  <p>
 	    We will construct the matrix whose columns are
@@ -78,9 +81,6 @@
 	    <m>\laspan{\vvec_1,\vvec_2,\vvec_3} = \real^3</m>.
 	  </p>
         </solution>
-        <answer>
-          <p><m>\laspan{\vvec_1,\vvec_2,\vvec_3} = \real^3</m>.</p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-4-b">
@@ -102,6 +102,10 @@
 	  </sage>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p><m>\laspan{\wvec_1, \wvec_2, \wvec_3}</m> is a plane
+	  in <m>\real^3</m>.</p>
+        </answer>
         <solution>
 	  <p>
 	    Similarly,
@@ -123,10 +127,6 @@
 	    in <m>\real^3</m>.
 	  </p>
         </solution>
-        <answer>
-          <p><m>\laspan{\wvec_1, \wvec_2, \wvec_3}</m> is a plane
-	  in <m>\real^3</m>.</p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-4-c">
@@ -141,6 +141,10 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p><m>\wvec_3 = \wvec_1 +
+	  \wvec_2</m>.</p>
+        </answer>
         <solution>
 	  <p>
 	    We see that
@@ -165,10 +169,6 @@
 	    \wvec_2</m>.
 	  </p>
         </solution>
-        <answer>
-          <p><m>\wvec_3 = \wvec_1 +
-	  \wvec_2</m>.</p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-4-d">
@@ -184,16 +184,6 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    We have
-	    <md>
-	      c_1\wvec_1 + c_2\wvec_2 + c_3\wvec_3 =
-	      c_1\wvec_1 + c_2\wvec_2 + c_3(\wvec_1+\wvec_2)=
-	      (c_1+c_3)\wvec_1 + (c_2+c_3)\wvec_2.
-	    </md>
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    We have
@@ -204,6 +194,16 @@
 	    </md>
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    We have
+	    <md>
+	      c_1\wvec_1 + c_2\wvec_2 + c_3\wvec_3 =
+	      c_1\wvec_1 + c_2\wvec_2 + c_3(\wvec_1+\wvec_2)=
+	      (c_1+c_3)\wvec_1 + (c_2+c_3)\wvec_2.
+	    </md>
+	  </p>
+        </solution>
       </task>
       <task label="ula-preview-2-4-e">
         <statement>
@@ -215,13 +215,6 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    Any linear combination of <m>\wvec_1</m>,
-	    <m>\wvec_2</m>, and <m>\wvec_3</m> is itself a linear
-	    combination of <m>\wvec_1</m> and <m>\wvec_2</m>.
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    Any linear combination of <m>\wvec_1</m>,
@@ -229,6 +222,13 @@
 	    combination of <m>\wvec_1</m> and <m>\wvec_2</m>.
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    Any linear combination of <m>\wvec_1</m>,
+	    <m>\wvec_2</m>, and <m>\wvec_3</m> is itself a linear
+	    combination of <m>\wvec_1</m> and <m>\wvec_2</m>.
+	  </p>
+        </solution>
       </task>
 
       <task component="rs-preview">

--- a/src/section2-5.xml
+++ b/src/section2-5.xml
@@ -45,12 +45,12 @@
 	  <p> What is the value of <m>f(3)</m>? </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p> We find <m>f(3) = 3^2 = 9</m>. </p>
-        </solution>
         <answer>
           <p><m>f(3) = 3^2 = 9</m>. </p>
         </answer>
+        <solution>
+	  <p> We find <m>f(3) = 3^2 = 9</m>. </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-5-b">
@@ -59,13 +59,13 @@
 	  the solution unique? </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p>There is not a unique solution.</p>
+        </answer>
         <solution>
 	  <p> If <m>f(x)=x^2 = 4</m>, then <m>x = \pm2</m> so
 	  there is not a unique solution. </p>
         </solution>
-        <answer>
-          <p>There is not a unique solution.</p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-5-c">
@@ -74,13 +74,13 @@
 	  the solution unique? </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p>There are no solutions.</p>
+        </answer>
         <solution>
 	  <p> There are no solutions to the equation
 	  <m>f(x)=x^2=-10</m>. </p>
         </solution>
-        <answer>
-          <p>There are no solutions.</p>
-        </answer>
       </task>
 
       <task label="ula-preview-2-5-d"
@@ -114,14 +114,6 @@
           </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <image width="50%">
-            <prefigure xmlns="https://prefigure.org"
-                       label="pf-ex-graph-x-squared">
-              <xi:include href="prefigure/section2-5/ex-graph-x-squared.xml"/>
-            </prefigure>
-          </image>
-        </solution>
         <answer>
 	  <image width="50%">
             <prefigure xmlns="https://prefigure.org"
@@ -130,6 +122,14 @@
             </prefigure>
           </image>
         </answer>
+        <solution>
+	  <image width="50%">
+            <prefigure xmlns="https://prefigure.org"
+                       label="pf-ex-graph-x-squared">
+              <xi:include href="prefigure/section2-5/ex-graph-x-squared.xml"/>
+            </prefigure>
+          </image>
+        </solution>
       </task>
 
       <task label="ula-preview-2-5-e">
@@ -184,23 +184,6 @@
           your response after completing the next part of this activity.
           </p>
         </statement>
-        <solution>
-	  <p> The graph is shown on the left below.</p>
-	  <sidebyside widths="45% 45%">
-	    <image>
-              <prefigure xmlns="https://prefigure.org"
-                         label="pf-ex-graph-2x">
-                <xi:include href="prefigure/section2-5/ex-graph-2x.xml"/>
-              </prefigure>
-            </image>
-	    <image>
-              <prefigure xmlns="https://prefigure.org"
-                         label="pf-ex-graph-fracx">
-                <xi:include href="prefigure/section2-5/ex-graph-fracx.xml"/>
-              </prefigure>
-            </image>
-	  </sidebyside>
-        </solution>
         <answer>
 	  <p> The graph is shown on the left below.</p>
 	  <sidebyside widths="45% 45%">
@@ -218,6 +201,23 @@
             </image>
 	  </sidebyside>
         </answer>
+        <solution>
+	  <p> The graph is shown on the left below.</p>
+	  <sidebyside widths="45% 45%">
+	    <image>
+              <prefigure xmlns="https://prefigure.org"
+                         label="pf-ex-graph-2x">
+                <xi:include href="prefigure/section2-5/ex-graph-2x.xml"/>
+              </prefigure>
+            </image>
+	    <image>
+              <prefigure xmlns="https://prefigure.org"
+                         label="pf-ex-graph-fracx">
+                <xi:include href="prefigure/section2-5/ex-graph-fracx.xml"/>
+              </prefigure>
+            </image>
+	  </sidebyside>
+        </solution>
       </task>
 
       <task label="ula-preview-2-5-f"
@@ -230,12 +230,12 @@
           </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p> The graph is shown on the right above. </p>
-        </solution>
         <answer>
 	  <p> The graph is shown on the right above. </p>
         </answer>
+        <solution>
+	  <p> The graph is shown on the right above. </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-5-g">
@@ -247,6 +247,10 @@
 	  </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p><m>g(h(x)) =
+	  g(-\frac13x)= -\frac23 x</m>.</p>
+        </answer>
         <solution>
 	  <p> Composing the functions, we find that <m>g(h(x)) =
 	  g(-\frac13x)= -\frac23 x</m>.  We see that the composition
@@ -254,10 +258,6 @@
 	  multiplying the slopes of <m>g</m> and <m>h</m>.
 	  </p>
         </solution>
-        <answer>
-          <p><m>g(h(x)) =
-	  g(-\frac13x)= -\frac23 x</m>.</p>
-        </answer>
       </task>
 
       <task component="rs-preview">

--- a/src/section2-6.xml
+++ b/src/section2-6.xml
@@ -52,16 +52,16 @@
 	  <m>\xvec</m> and <m>T(\xvec)</m>. </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    <m>T(\xvec) = \twovec{2}{-4}</m>.
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    <m>T(\xvec) = \twovec{2}{-4}</m>.
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    <m>T(\xvec) = \twovec{2}{-4}</m>.
+	  </p>
+        </solution>
       </task>
 
       <task label="ula-preview-2-6-b">
@@ -70,16 +70,16 @@
 	  <m>T(\xvec)</m>?  </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    <m>T(\xvec) = \twovec{x}{-y}</m>.
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    <m>T(\xvec) = \twovec{x}{-y}</m>.
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    <m>T(\xvec) = \twovec{x}{-y}</m>.
+	  </p>
+        </solution>
       </task>
       <task label="ula-preview-2-6-c">
         <statement>
@@ -87,18 +87,18 @@
 	  and <m>T\left(\twovec{0}{1}\right)</m>. </p>
         </statement>
         <response component="rs-preview"/>
-        <solution>
-	  <p>
-	    <m>T\left(\twovec{1}{0}\right) = \twovec{1}{0}</m> and
-	    <m>T\left(\twovec{0}{1}\right) = \twovec{0}{-1}</m>.
-	  </p>
-        </solution>
         <answer>
 	  <p>
 	    <m>T\left(\twovec{1}{0}\right) = \twovec{1}{0}</m> and
 	    <m>T\left(\twovec{0}{1}\right) = \twovec{0}{-1}</m>.
 	  </p>
         </answer>
+        <solution>
+	  <p>
+	    <m>T\left(\twovec{1}{0}\right) = \twovec{1}{0}</m> and
+	    <m>T\left(\twovec{0}{1}\right) = \twovec{0}{-1}</m>.
+	  </p>
+        </solution>
       </task>
       <task label="ula-preview-2-6-d">
         <statement>
@@ -108,6 +108,13 @@
 	  with what you found in part b. </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p><m>A=\left[\begin{array}{rr}
+	    1 \amp 0 \\
+	    0 \amp -1 \\
+	    \end{array}\right]</m>.
+          </p>
+        </answer>
         <solution>
 	  <p>
 	    We have the matrix
@@ -119,13 +126,6 @@
 	    \twovec{x}{-y}</m> as expected.
 	  </p>
         </solution>
-        <answer>
-          <p><m>A=\left[\begin{array}{rr}
-	    1 \amp 0 \\
-	    0 \amp -1 \\
-	    \end{array}\right]</m>.
-          </p>
-        </answer>
       </task>
       <task label="ula-preview-2-6-e">
         <statement>
@@ -135,6 +135,12 @@
 	  multiplication can be used to justify your response. </p>
         </statement>
         <response component="rs-preview"/>
+        <answer>
+          <p><m>AA= A^2 = \left[\begin{array}{rr}1\amp 0 \\ 0
+	    \amp 1 \\
+	    \end{array}\right]</m>.
+          </p>
+        </answer>
         <solution>
 	  <p>
 	    If we reflect a vector twice in the horizontal axis, we
@@ -145,12 +151,6 @@
 	    \end{array}\right]</m>.
 	  </p>
         </solution>
-        <answer>
-          <p><m>AA= A^2 = \left[\begin{array}{rr}1\amp 0 \\ 0
-	    \amp 1 \\
-	    \end{array}\right]</m>.
-          </p>
-        </answer>
       </task>
 
       <task component="rs-preview">

--- a/src/section6-1.xml
+++ b/src/section6-1.xml
@@ -453,6 +453,62 @@
 	    </li>
 	</ol></p>
       </statement>
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <image width="50%">
+                <prefigure xmlns="https://prefigure.org"
+                           label="pf-ex-6-1-1-plot-ans">
+                  <xi:include
+                      href="prefigure/section6-1/ex-6-1-1-plot.xml"/>
+                </prefigure>
+              </image>
+	    </li>
+
+	    <li>
+	      <p>
+		<m>\len{\vvec} = \sqrt{13}</m> and <m>\len{\wvec} =
+		\sqrt{10}</m>.
+	      </p>
+	    </li>
+
+	    <li>
+	      <p>
+		<m>
+		  \theta =
+		  = 52.1^\circ.
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>
+		  \theta =
+		  = 90^\circ.
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Their dot product
+		must be zero.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>k=2</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>55.9^\circ</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -528,62 +584,6 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <image width="50%">
-                <prefigure xmlns="https://prefigure.org"
-                           label="pf-ex-6-1-1-plot-ans">
-                  <xi:include
-                      href="prefigure/section6-1/ex-6-1-1-plot.xml"/>
-                </prefigure>
-              </image>
-	    </li>
-
-	    <li>
-	      <p>
-		<m>\len{\vvec} = \sqrt{13}</m> and <m>\len{\wvec} =
-		\sqrt{10}</m>.
-	      </p>
-	    </li>
-
-	    <li>
-	      <p>
-		<m> 
-		  \theta =
-		  = 52.1^\circ.
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>
-		  \theta =
-		  = 90^\circ.
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Their dot product
-		must be zero.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>k=2</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>55.9^\circ</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-
-      </answer>
     </activity>
 
     <p> As we move forward, it will be important for us to recognize
@@ -934,6 +934,79 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
       </p>
     </statement>
 
+    <answer>
+      <p>
+	<ol marker="a.">
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p> They are perpendicular.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    The angle should be close to 0.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    The angle <c>veterans</c> makes with
+		    <c>memorial</c> is <m>46.4^\circ</m>, with
+		    <c>labor</c> is <m>59.2^\circ</m>, with
+		    <c>golden</c> is <m>86.2^\circ</m>, and with
+		    <c>super</c> is <m>86.4^\circ</m>.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    The articles on Veteran's Day and
+		    Memorial Day are most similar.
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	  <li>
+	    <p>
+	      <ol marker="1.">
+		<li>
+		  <p>
+		    The graphs are now lowered so that their averages
+		    are zero.
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>0.98</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>1</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>-1</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>-0.87</m>
+		  </p>
+		</li>
+		<li>
+		  <p>
+		    <m>-0.10</m>
+		  </p>
+		</li>
+	      </ol>
+	    </p>
+	  </li>
+	</ol>
+      </p>
+    </answer>
     <solution>
       <p>
 	<ol marker="a.">
@@ -1020,79 +1093,6 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
       </p>
     </solution>
 
-    <answer>
-      <p>
-	<ol marker="a.">
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p> They are perpendicular.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    The angle should be close to 0.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    The angle <c>veterans</c> makes with
-		    <c>memorial</c> is <m>46.4^\circ</m>, with
-		    <c>labor</c> is <m>59.2^\circ</m>, with
-		    <c>golden</c> is <m>86.2^\circ</m>, and with
-		    <c>super</c> is <m>86.4^\circ</m>.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    The articles on Veteran's Day and
-		    Memorial Day are most similar.
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	  <li>
-	    <p>
-	      <ol marker="1.">
-		<li>
-		  <p>
-		    The graphs are now lowered so that their averages
-		    are zero.
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>0.98</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>1</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>-1</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>-0.87</m>
-		  </p>
-		</li>
-		<li>
-		  <p>
-		    <m>-0.10</m>
-		  </p>
-		</li>
-	      </ol>
-	    </p>
-	  </li>
-	</ol>
-      </p>
-    </answer>
   </activity>
   
 
@@ -1377,6 +1377,54 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		The centroid is <m>c = \twovec32</m>.
+	      </p>
+	      <image width="50%">
+                <prefigure xmlns="https://prefigure.org"
+                           label="pf-k-means-6-1-ans">
+                  <xi:include href="prefigure/section6-1/k-means-6-1.xml"/>
+                </prefigure>
+              </image>
+	    </li>
+
+	    <li>
+	      <p>
+		<m>C_1 = \{\vvec_1,
+		\vvec_2\}</m>.
+	      </p>
+	    </li>
+
+	    <li>
+	      <p>
+		<m>C_2=\{\vvec_3,\vvec_4\}</m>.
+	      </p>
+	    </li>
+
+	    <li>
+	      <p>
+		<m>c_1 = \twovec{-1/2}{0}</m> and <m>c_2 =
+		\twovec22</m>
+	      </p>
+	      <p>
+		<m>C_1 = \{\vvec_1\}</m> and <m>C_2=\{\vvec_2, \vvec_3,
+		\vvec_4\}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>c_1 = \twovec{-2}1</m> and
+		<m>c_2 = \twovec{5/3}{5/3}</m>.  The clusters
+		<m>C_1</m> and <m>C_2</m> are unchanged.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1425,54 +1473,6 @@ series_plot(s1, 'blue') + series_plot(s4, 'orange')
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		The centroid is <m>c = \twovec32</m>.
-	      </p>
-	      <image width="50%">
-                <prefigure xmlns="https://prefigure.org"
-                           label="pf-k-means-6-1-ans">
-                  <xi:include href="prefigure/section6-1/k-means-6-1.xml"/>
-                </prefigure>
-              </image>
-	    </li>
-
-	    <li>
-	      <p>
-		<m>C_1 = \{\vvec_1,
-		\vvec_2\}</m>.
-	      </p>
-	    </li>
-
-	    <li>
-	      <p>
-		<m>C_2=\{\vvec_3,\vvec_4\}</m>.
-	      </p>
-	    </li>
-
-	    <li>
-	      <p>
-		<m>c_1 = \twovec{-1/2}{0}</m> and <m>c_2 =
-		\twovec22</m>
-	      </p>
-	      <p>
-		<m>C_1 = \{\vvec_1\}</m> and <m>C_2=\{\vvec_2, \vvec_3,
-		\vvec_4\}</m>. 
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>c_1 = \twovec{-2}1</m> and
-		<m>c_2 = \twovec{5/3}{5/3}</m>.  The clusters
-		<m>C_1</m> and <m>C_2</m> are unchanged.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <p>
@@ -1733,6 +1733,49 @@ plotclusters(clusters, centroids)
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		The objective is <m>5/6</m>.
+	      </p>
+	    </li>
+
+	    <li>
+	      <p>
+		The clustering <m>C_1=\{\vvec_1\}</m> and <m>C_2
+		= \{\vvec_2, \vvec_3, \vvec_4\}</m> has a smaller
+		objective.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>k=6</m> or <m>k=7</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		With a fixed value of <m>k</m>, running the algorithm
+		several times leads to different clusterings with
+		different objectives.  If we increase <m>k</m>, the
+		objective generally decreases.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The elbow occurs around <m>k=6</m> or <m>k=7</m>.
+	      </p>
+	      <image width="90%">
+                <prefigure xmlns="https://prefigure.org"
+                           label="pf-clusterin-elbow-plot-ans">
+                  <xi:include href="prefigure/section6-1/clustering-elbow-plot.xml"/>
+                </prefigure>
+              </image>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1785,51 +1828,8 @@ plotclusters(clusters, centroids)
 	  </ol>
 	</p>
       </solution>
-	    
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		The objective is <m>5/6</m>.
-	      </p>
-	    </li>
 
-	    <li>
-	      <p>
-		The clustering <m>C_1=\{\vvec_1\}</m> and <m>C_2
-		= \{\vvec_2, \vvec_3, \vvec_4\}</m> has a smaller
-		objective. 
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>k=6</m> or <m>k=7</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		With a fixed value of <m>k</m>, running the algorithm
-		several times leads to different clusterings with
-		different objectives.  If we increase <m>k</m>, the
-		objective generally decreases.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The elbow occurs around <m>k=6</m> or <m>k=7</m>.
-	      </p>
-	      <image width="90%">
-                <prefigure xmlns="https://prefigure.org"
-                           label="pf-clusterin-elbow-plot-ans">
-                  <xi:include href="prefigure/section6-1/clustering-elbow-plot.xml"/>
-                </prefigure>
-              </image>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	    
+
     </activity>
 
     <p>

--- a/src/section6-2.xml
+++ b/src/section6-2.xml
@@ -326,6 +326,56 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>\wvec_1\cdot\xvec = x_1 - 2x_3
+		= 0</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\wvec_2\cdot\xvec = x_1+x_2 - x_3
+		= 0</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>
+		  B = \begin{bmatrix}
+		  1 \amp 0 \amp -2 \\
+		  1 \amp 1 \amp -1 \\
+		  \end{bmatrix}
+		</m>
+		so
+		<m>\xvec=x_3\threevec2{-1}1</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		By distributivity,
+		<m>(c_1\wvec_1+c_2\wvec_2)\cdot\xvec=
+		c_1\wvec_1\cdot\xvec + c_2\wvec_2\cdot\xvec = 0</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		A basis consists of
+		<m>\threevec1{-1}1</m>, and <m>W^\perp</m> is
+		one-dimensional.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The orthogonal complement of
+		<m>W^\perp</m> is <m>W</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -386,56 +436,6 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>\wvec_1\cdot\xvec = x_1 - 2x_3
-		= 0</m>. 
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\wvec_2\cdot\xvec = x_1+x_2 - x_3
-		= 0</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>
-		  B = \begin{bmatrix}
-		  1 \amp 0 \amp -2 \\
-		  1 \amp 1 \amp -1 \\
-		  \end{bmatrix}
-		</m>
-		so
-		<m>\xvec=x_3\threevec2{-1}1</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		By distributivity,
-		<m>(c_1\wvec_1+c_2\wvec_2)\cdot\xvec=
-		c_1\wvec_1\cdot\xvec + c_2\wvec_2\cdot\xvec = 0</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		A basis consists of
-		<m>\threevec1{-1}1</m>, and <m>W^\perp</m> is
-		one-dimensional.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The orthogonal complement of
-		<m>W^\perp</m> is <m>W</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <example xml:id="example-orthog-comp-line">
@@ -653,6 +653,57 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>A^T = \begin{bmatrix}
+		3 \amp -1 \amp 0 \\
+		4 \amp 2 \amp -2
+		\end{bmatrix}
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\vvec_1\cdot\wvec =-10</m>,
+		<m>\vvec_2\cdot\wvec =6</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>A^T\wvec
+		=\twovec{\vvec_1\cdot\wvec}{\vvec_2\cdot\wvec}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A^T\xvec =
+		\zerovec</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\xvec=x_3\threevec1{-3}1</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A^T\xvec =
+		\twovec{\vvec_1\cdot\xvec}{\vvec_2\cdot\xvec} =
+		\twovec00</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Apply the distributive property of dot products.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -729,58 +780,7 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>A^T = \begin{bmatrix}
-		3 \amp -1 \amp 0 \\
-		4 \amp 2 \amp -2
-		\end{bmatrix}
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\vvec_1\cdot\wvec =-10</m>,
-		<m>\vvec_2\cdot\wvec =6</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>A^T\wvec 
-		=\twovec{\vvec_1\cdot\wvec}{\vvec_2\cdot\wvec}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A^T\xvec =
-		\zerovec</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\xvec=x_3\threevec1{-3}1</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A^T\xvec =
-		\twovec{\vvec_1\cdot\xvec}{\vvec_2\cdot\xvec} =
-		\twovec00</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Apply the distributive property of dot products.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		    
+
     </activity>
 
     <p>
@@ -987,6 +987,42 @@
 	</ol></p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>(A+B)^T = A^T + B^T</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>(A^T)^T = A</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\det(C^T) = \det(C)</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>(AC)^T=C^TA^T</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>I^T=I</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>(D^T)^{-1} = (D^{-1})^T</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1054,44 +1090,8 @@
 	  </ol>
 	</p>
       </solution>
-	    
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>(A+B)^T = A^T + B^T</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>(A^T)^T = A</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\det(C^T) = \det(C)</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>(AC)^T=C^TA^T</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>I^T=I</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>(D^T)^{-1} = (D^{-1})^T</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		      
+
+
     </activity>
 	
     <p> In spite of the fact that we are looking at some specific
@@ -1280,6 +1280,75 @@
 	  </ol>
 	</p>
       </statement>
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      <m>9\times 5</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>5</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>5\times 9</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>5</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>4</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>4</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\dim W + \dim W^\perp = 9 </m>
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      <m>2</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		    <m>\fourvec1{-1}01</m> and
+		    <m>\fourvec0012</m> .
+		    </p>
+		  </li>
+		  <li>
+		    <p>Verify by computing the four dot
+		    products.
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1351,75 +1420,6 @@
 	  </ol>
 	</p>
       </solution>
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      <m>9\times 5</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>5</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>5\times 9</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>5</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>4</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>4</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\dim W + \dim W^\perp = 9 </m>
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      <m>2</m> 
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		    <m>\fourvec1{-1}01</m> and
-		    <m>\fourvec0012</m> .
-		    </p>
-		  </li>
-		  <li>
-		    <p>Verify by computing the four dot
-		    products.
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
   </subsection>

--- a/src/section6-3.xml
+++ b/src/section6-3.xml
@@ -408,6 +408,56 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		We compute the dot products
+		<m>\wvec_1\cdot\wvec_2=0</m>,
+		<m>\wvec_1\cdot\wvec_3=0</m>, and
+		<m>\wvec_2\cdot\wvec_3=0</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		An orthogonal set of vectors is linearly
+		independent.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\bvec = -2\wvec_1 + 3\wvec_2 +
+		\wvec_3</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>
+		  \uvec_1 = \frac{1}{\sqrt{3}}\wvec_1 =
+		  \threevec{1/\sqrt{3}}{-1/\sqrt{3}}{1/\sqrt{3}}
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We find that
+		<md>
+		  \uvec_2 =
+		  \threevec{1/\sqrt{2}}{1/\sqrt{2}}0,\hspace{24pt}
+		  \uvec_3 =
+		  \threevec{1/\sqrt{6}}{-1/\sqrt{6}}{-2/\sqrt{6}}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>Q^TQ=I</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -462,58 +512,8 @@
 	  </ol>
 	</p>
       </solution>
-		  
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		We compute the dot products
-		<m>\wvec_1\cdot\wvec_2=0</m>,
-		<m>\wvec_1\cdot\wvec_3=0</m>, and
-		<m>\wvec_2\cdot\wvec_3=0</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		An orthogonal set of vectors is linearly
-		independent.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\bvec = -2\wvec_1 + 3\wvec_2 +
-		\wvec_3</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>
-		  \uvec_1 = \frac{1}{\sqrt{3}}\wvec_1 =
-		  \threevec{1/\sqrt{3}}{-1/\sqrt{3}}{1/\sqrt{3}}
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We find that
-		<md>
-		  \uvec_2 =
-		  \threevec{1/\sqrt{2}}{1/\sqrt{2}}0,\hspace{24pt}
-		  \uvec_3 =
-		  \threevec{1/\sqrt{6}}{-1/\sqrt{6}}{-2/\sqrt{6}}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>Q^TQ=I</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
+
     </activity>
 
     <p>
@@ -995,6 +995,76 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      0
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\bhat = \twovec{16/5}{8/5}</m>.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\bhat=
+		      \frac{\bvec\cdot\wvec}{\wvec\cdot\wvec}\wvec</m>
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      0
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>c_1= 2</m>
+		    </p>
+		    <p>
+		      <m>c_2=3</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\bhat = \threevec744</m>
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We require that <m>\bvec-\bhat</m> be orthogonal to
+		every vector <m>\wvec_i</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>c_i=\frac{\bvec\cdot\uvec_i}{\uvec_i\cdot\uvec_i} =
+		\bvec\cdot\uvec_i</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Use the fact that <m>Q^T\bvec =
+		\threevec{\bvec\cdot\uvec_1}{\vdots}{\bvec\cdot\uvec_n}</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1083,77 +1153,7 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      0
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\bhat = \twovec{16/5}{8/5}</m>.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\bhat=
-		      \frac{\bvec\cdot\wvec}{\wvec\cdot\wvec}\wvec</m>
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      0
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>c_1= 2</m>
-		    </p>
-		    <p>
-		      <m>c_2=3</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\bhat = \threevec744</m>
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We require that <m>\bvec-\bhat</m> be orthogonal to
-		every vector <m>\wvec_i</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>c_i=\frac{\bvec\cdot\uvec_i}{\uvec_i\cdot\uvec_i} =
-		\bvec\cdot\uvec_i</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Use the fact that <m>Q^T\bvec =
-		\threevec{\bvec\cdot\uvec_1}{\vdots}{\bvec\cdot\uvec_n}</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		      
+
     </activity>
 
     <p>
@@ -1489,6 +1489,89 @@
 	  </ol>
 	</p>
       </statement>
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      <m>\uvec=\threevec{1/3}{2/3}{-2/3}</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>QQ^T = \begin{bmatrix}
+		      1/9 \amp 2/9 \amp -2/9 \\
+		      2/9 \amp 4/9 \amp -4/9 \\
+		      -2/9 \amp -4/9 \amp 4/9
+		      \end{bmatrix}</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\bhat=\threevec{1/9}{2/9}{-2/9}</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\rank(P)=1</m>
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      <m>\bhat = \fourvec3235</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>P = \begin{bmatrix}
+		      1/4 \amp 1/4 \amp 1/4 \amp 1/4 \\
+		      1/4 \amp 5/12 \amp 5/12 \amp -1/12 \\
+		      1/4 \amp 5/12 \amp 5/12 \amp 1/12 \\
+		      1/4 \amp -1/12 \amp -1/12 \amp 11/12
+		      \end{bmatrix}
+		      </m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\rank(P)=2</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\vvec_1=\fourvec0{-1}10</m> and
+		      <m>\vvec_2=\fourvec{-3}{-2}01</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\bvec^\perp =
+		      \fourvec60{-4}{-2}</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>Q^TQ = \begin{bmatrix}
+		      1 \amp 0 \\
+		      0 \amp 1
+		      \end{bmatrix}</m>
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1578,90 +1661,7 @@
 	  </ol>
 	</p>
       </solution>
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      <m>\uvec=\threevec{1/3}{2/3}{-2/3}</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>QQ^T = \begin{bmatrix}
-		      1/9 \amp 2/9 \amp -2/9 \\
-		      2/9 \amp 4/9 \amp -4/9 \\
-		      -2/9 \amp -4/9 \amp 4/9
-		      \end{bmatrix}</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\bhat=\threevec{1/9}{2/9}{-2/9}</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\rank(P)=1</m>
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      <m>\bhat = \fourvec3235</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>P = \begin{bmatrix}
-		      1/4 \amp 1/4 \amp 1/4 \amp 1/4 \\
-		      1/4 \amp 5/12 \amp 5/12 \amp -1/12 \\
-		      1/4 \amp 5/12 \amp 5/12 \amp 1/12 \\
-		      1/4 \amp -1/12 \amp -1/12 \amp 11/12
-		      \end{bmatrix}
-		      </m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\rank(P)=2</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\vvec_1=\fourvec0{-1}10</m> and
-		      <m>\vvec_2=\fourvec{-3}{-2}01</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\bvec^\perp = 
-		      \fourvec60{-4}{-2}</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>Q^TQ = \begin{bmatrix}
-		      1 \amp 0 \\
-		      0 \amp 1
-		      \end{bmatrix}</m>
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
     </activity>
 
     <p>

--- a/src/section6-4.xml
+++ b/src/section6-4.xml
@@ -336,6 +336,59 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>\widehat{\vvec}_2 = \fourvec2222</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\wvec_2 = \fourvec{-1}100</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We have <m>\vvec_1 = \wvec_1</m> and <m>\vvec_2 =
+		\wvec_2 + 2\wvec_1</m> so a linear
+		combination of <m>\vvec_1</m> and <m>\vvec_1</m> can
+		be rewritten as a linear combination of <m>\wvec_1</m>
+		and <m>\wvec_2</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\widehat{\vvec}_3 =
+		\fourvec0{-4}{-2}{-2}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\wvec_3 = \fourvec11{-1}{-1}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Since
+		<m>\vvec_i</m> can be written in terms of
+		<m>\wvec_j</m> and vice-versa, these new vectors form
+		a basis for <m>W</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  \uvec_1=\fourvec{1/2}{1/2}{1/2}{1/2},\hspace{24pt}
+		  \uvec_2=\fourvec{-1/\sqrt{2}}{1/\sqrt{2}}00,\hspace{24pt}
+		  \uvec_3=\fourvec{1/2}{1/2}{-1/2}{-1/2}
+		</md>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -400,61 +453,8 @@
 	  </ol>
 	</p>
       </solution>
-		
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>\widehat{\vvec}_2 = \fourvec2222</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\wvec_2 = \fourvec{-1}100</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We have <m>\vvec_1 = \wvec_1</m> and <m>\vvec_2 =
-		\wvec_2 + 2\wvec_1</m> so a linear
-		combination of <m>\vvec_1</m> and <m>\vvec_1</m> can
-		be rewritten as a linear combination of <m>\wvec_1</m>
-		and <m>\wvec_2</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\widehat{\vvec}_3 =
-		\fourvec0{-4}{-2}{-2}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\wvec_3 = \fourvec11{-1}{-1}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Since
-		<m>\vvec_i</m> can be written in terms of
-		<m>\wvec_j</m> and vice-versa, these new vectors form
-		a basis for <m>W</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  \uvec_1=\fourvec{1/2}{1/2}{1/2}{1/2},\hspace{24pt}
-		  \uvec_2=\fourvec{-1/\sqrt{2}}{1/\sqrt{2}}00,\hspace{24pt}
-		  \uvec_3=\fourvec{1/2}{1/2}{-1/2}{-1/2}
-		</md>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
+
     </activity>
 
     <p>
@@ -711,6 +711,60 @@ sage.repl.load.load("https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<md>
+		  \wvec_1=\fivevec{14}{-6}82{-6},\hspace{24pt}
+		  \wvec_2=\fivevec{-2}{0}02{-4},\hspace{24pt}
+		  \wvec_3=\fivevec130{-1}{-1}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\bhat=\fivevec{-4}9{-4}{-4}3</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\bhat=-\frac34\vvec_1+\frac12\vvec_2+2\vvec_3</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  \uvec_1=\fivevec{14/\sqrt{336}}{-6\sqrt{336}}{8/\sqrt{336}}
+		  {2/\sqrt{336}}{-6/\sqrt{336}},\hspace{24pt}
+		  \uvec_2=\fivevec{-2/\sqrt{24}}{0}0{2/\sqrt{24}}
+		  {-4/\sqrt{24}},\hspace{24pt}
+		  \uvec_3=\fivevec{1/\sqrt{12}}{3/\sqrt{12}}0
+		  {-1/\sqrt{12}}{-1/\sqrt{12}}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>Q^TQ=I</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>P = QQ^T = \begin{bmatrix}
+		5/6 \amp 0 \amp 1/3 \amp -1/6 \amp 0 \\
+		0 \amp 6/7 \amp -1/7 \amp -2/7 \amp -1/7 \\
+		1/3 \amp -1/7 \amp 4/21 \amp 1/21 \amp -1/7 \\
+		-1/6 \amp -2/7 \amp 1/21 \amp 11/42 \amp -2/7 \\
+		0 \amp -1/7 \amp -1/7 \amp -2/7 \amp 6/7
+		\end{bmatrix}
+		</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -767,62 +821,8 @@ sage.repl.load.load("https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	  </ol>
 	</p>
       </solution>
-		
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<md>
-		  \wvec_1=\fivevec{14}{-6}82{-6},\hspace{24pt}
-		  \wvec_2=\fivevec{-2}{0}02{-4},\hspace{24pt}
-		  \wvec_3=\fivevec130{-1}{-1}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\bhat=\fivevec{-4}9{-4}{-4}3</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\bhat=-\frac34\vvec_1+\frac12\vvec_2+2\vvec_3</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  \uvec_1=\fivevec{14/\sqrt{336}}{-6\sqrt{336}}{8/\sqrt{336}}
-		  {2/\sqrt{336}}{-6/\sqrt{336}},\hspace{24pt}
-		  \uvec_2=\fivevec{-2/\sqrt{24}}{0}0{2/\sqrt{24}}
-		  {-4/\sqrt{24}},\hspace{24pt}
-		  \uvec_3=\fivevec{1/\sqrt{12}}{3/\sqrt{12}}0
-		  {-1/\sqrt{12}}{-1/\sqrt{12}}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>Q^TQ=I</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>P = QQ^T = \begin{bmatrix}
-		5/6 \amp 0 \amp 1/3 \amp -1/6 \amp 0 \\
-		0 \amp 6/7 \amp -1/7 \amp -2/7 \amp -1/7 \\
-		1/3 \amp -1/7 \amp 4/21 \amp 1/21 \amp -1/7 \\
-		-1/6 \amp -2/7 \amp 1/21 \amp 11/42 \amp -2/7 \\
-		0 \amp -1/7 \amp -1/7 \amp -2/7 \amp 6/7
-		\end{bmatrix}
-		</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
+
     </activity>
 
   </subsection>
@@ -962,6 +962,64 @@ sage.repl.load.load("https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<md>
+		  \begin{aligned}
+		  \vvec_1 \amp = \wvec_1 \\
+		  \vvec_2 \amp = 2\wvec_1 + \wvec_2 \\
+		  \vvec_3 \amp = -2\wvec_1 - 2\wvec_2 + \wvec_3 \\
+		  \end{aligned}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  \begin{aligned}
+		  \vvec_1 \amp = 2\uvec_1 \\
+		  \vvec_2 \amp = 4\uvec_1 + \sqrt{2}\uvec_2 \\
+		  \vvec_3 \amp = -4\uvec_1 - 2\sqrt{2}\uvec_2 + 2\uvec_3 \\
+		  \end{aligned}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\vvec_1 =
+		Q\threevec{2}00</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\vvec_2 =
+		Q\threevec4{\sqrt{2}}0</m> and
+		<m>\vvec_3=Q\threevec{-4}{-2\sqrt{2}}2</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We have <m>QR = \begin{bmatrix} Q\rvec_1 \amp Q\rvec_2
+		\amp Q\rvec_3 \end{bmatrix} = A</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>R</m> is upper triangular.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>Q</m> will be <m>10\times6</m> and <m>R</m> will be
+		<m>6\times 6</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1041,65 +1099,7 @@ sage.repl.load.load("https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<md>
-		  \begin{aligned}
-		  \vvec_1 \amp = \wvec_1 \\
-		  \vvec_2 \amp = 2\wvec_1 + \wvec_2 \\
-		  \vvec_3 \amp = -2\wvec_1 - 2\wvec_2 + \wvec_3 \\
-		  \end{aligned}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  \begin{aligned}
-		  \vvec_1 \amp = 2\uvec_1 \\
-		  \vvec_2 \amp = 4\uvec_1 + \sqrt{2}\uvec_2 \\
-		  \vvec_3 \amp = -4\uvec_1 - 2\sqrt{2}\uvec_2 + 2\uvec_3 \\
-		  \end{aligned}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\vvec_1 =
-		Q\threevec{2}00</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\vvec_2 =
-		Q\threevec4{\sqrt{2}}0</m> and
-		<m>\vvec_3=Q\threevec{-4}{-2\sqrt{2}}2</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We have <m>QR = \begin{bmatrix} Q\rvec_1 \amp Q\rvec_2
-		\amp Q\rvec_3 \end{bmatrix} = A</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>R</m> is upper triangular.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>Q</m> will be <m>10\times6</m> and <m>R</m> will be
-		<m>6\times 6</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
     </activity>
 
     <p>
@@ -1270,6 +1270,57 @@ sage.repl.load.load("https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>Q</m> is <m>4\times3</m> and <m>R</m> is a
+		<m>3\times3</m> upper triangular matrix.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We see that
+		<md>
+		  Q=\begin{bmatrix}
+		  1/\sqrt{3} \amp -1/\sqrt{10} \amp -3/\sqrt{23} \\
+		  0 \amp 2/\sqrt{10} \amp -3/\sqrt{23} \\
+		  1/\sqrt{3} \amp -1/\sqrt{10} \amp 1/\sqrt{23} \\
+		  1/\sqrt{3} \amp 2/\sqrt{10} \amp 2/\sqrt{23} \\
+		  \end{bmatrix},\hspace{24pt}
+		  R = \begin{bmatrix}
+		  \sqrt{3} \amp \sqrt{3} \amp \sqrt{3} \\
+		  0 \amp \sqrt{10} \amp \sqrt{10} \\
+		  0 \amp 0 \amp \sqrt{23}
+		  \end{bmatrix}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>P=QQ^T = \begin{bmatrix}
+		569/690 \amp 22/115 \amp 209/690 \amp -44/345 \\
+		22/115 \amp 91/115 \amp -38/115 \amp 16/115 \\
+		209/690 \amp -38/115 \amp 329/690 \amp 76/345 \\
+		-44/345 \amp 16/115 \amp 76/345 \amp 313/345 \\
+		\end{bmatrix}
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\bhat = \fourvec{-7}{-5}5{14}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\xvec = \threevec2{-1}3</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1324,59 +1375,8 @@ sage.repl.load.load("https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	  </ol>
 	</p>
       </solution>
-	    
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>Q</m> is <m>4\times3</m> and <m>R</m> is a
-		<m>3\times3</m> upper triangular matrix.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We see that
-		<md>
-		  Q=\begin{bmatrix}
-		  1/\sqrt{3} \amp -1/\sqrt{10} \amp -3/\sqrt{23} \\
-		  0 \amp 2/\sqrt{10} \amp -3/\sqrt{23} \\
-		  1/\sqrt{3} \amp -1/\sqrt{10} \amp 1/\sqrt{23} \\
-		  1/\sqrt{3} \amp 2/\sqrt{10} \amp 2/\sqrt{23} \\
-		  \end{bmatrix},\hspace{24pt}
-		  R = \begin{bmatrix}
-		  \sqrt{3} \amp \sqrt{3} \amp \sqrt{3} \\
-		  0 \amp \sqrt{10} \amp \sqrt{10} \\
-		  0 \amp 0 \amp \sqrt{23}
-		  \end{bmatrix}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>P=QQ^T = \begin{bmatrix}
-		569/690 \amp 22/115 \amp 209/690 \amp -44/345 \\
-		22/115 \amp 91/115 \amp -38/115 \amp 16/115 \\
-		209/690 \amp -38/115 \amp 329/690 \amp 76/345 \\
-		-44/345 \amp 16/115 \amp 76/345 \amp 313/345 \\
-		\end{bmatrix}
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\bhat = \fourvec{-7}{-5}5{14}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\xvec = \threevec2{-1}3</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	    
+
+
     </activity>
 
     <p>

--- a/src/section6-5.xml
+++ b/src/section6-5.xml
@@ -304,6 +304,72 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		It's not
+		possible to draw a line through all three points.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We have the equations
+		<md>
+		  <mrow>
+		    b + m \amp {}={} 1
+		  </mrow>
+		  <mrow>
+		    b + 2m \amp {}={} 1
+		  </mrow>
+		  <mrow>
+		    b + 3m \amp {}={} 3
+		  </mrow>
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We have <m>A = \begin{bmatrix}
+		1 \amp 1 \\
+		1 \amp 2 \\
+		1 \amp 3 \\
+		\end{bmatrix}</m> and <m>\bvec=\threevec113</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		This linear system is inconsistent.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\bhat=\threevec{2/3}{5/3}{8/3}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\xvec=\twovec{-1/3}1</m>.
+		This line is shown in <xref
+		ref="fig-best-fit-line-ans" />.
+	      </p>
+	      <figure xml:id="fig-best-fit-line-ans">
+		<caption>
+		  The line that best approximates the three data
+		  points.
+		</caption>
+		<image width="50%">
+                  <prefigure xmlns="https://prefigure.org"
+                             label="pf-line-regress-2-ans">
+                    <xi:include href="prefigure/section6-5/line-regress-2.xml"/>
+                  </prefigure>
+                </image>
+	      </figure>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -381,72 +447,6 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		It's not
-		possible to draw a line through all three points.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We have the equations
-		<md>
-		  <mrow>
-		    b + m \amp {}={} 1
-		  </mrow>
-		  <mrow>
-		    b + 2m \amp {}={} 1
-		  </mrow>
-		  <mrow>
-		    b + 3m \amp {}={} 3
-		  </mrow>
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We have <m>A = \begin{bmatrix}
-		1 \amp 1 \\
-		1 \amp 2 \\
-		1 \amp 3 \\
-		\end{bmatrix}</m> and <m>\bvec=\threevec113</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		This linear system is inconsistent.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\bhat=\threevec{2/3}{5/3}{8/3}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\xvec=\twovec{-1/3}1</m>.
-		This line is shown in <xref
-		ref="fig-best-fit-line-ans" />.
-	      </p>
-	      <figure xml:id="fig-best-fit-line-ans">
-		<caption>
-		  The line that best approximates the three data
-		  points.
-		</caption>
-		<image width="50%">
-                  <prefigure xmlns="https://prefigure.org"
-                             label="pf-line-regress-2-ans">
-                    <xi:include href="prefigure/section6-5/line-regress-2.xml"/>
-                  </prefigure>
-                </image>
-	      </figure>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
 
     </activity>
 
@@ -764,6 +764,46 @@ plot_model(xhat, data, domain=(12, 22))
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>\beta_0 + 20.0\beta_1 =
+		88.6</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A</m> is the <m>15\times2</m> matrix whose first
+		column consists only of 1's and whose second column is
+		the vector of chirp rates.  The vector <m>\bvec</m> is
+		the vector of temperatures.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A^TA=\begin{bmatrix}
+		15.0 \amp 248.5 \\
+		248.5 \amp 4157.9 \\
+		\end{bmatrix}</m> and <m>A^T\bvec =
+		\twovec{1190.2}{19857.7}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\xhat = \twovec{\beta_0}{\beta_1} =
+		\twovec{22.8}{3.4}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>97.9</m> degrees.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -806,46 +846,6 @@ plot_model(xhat, data, domain=(12, 22))
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>\beta_0 + 20.0\beta_1 =
-		88.6</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A</m> is the <m>15\times2</m> matrix whose first
-		column consists only of 1's and whose second column is
-		the vector of chirp rates.  The vector <m>\bvec</m> is
-		the vector of temperatures.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A^TA=\begin{bmatrix}
-		15.0 \amp 248.5 \\
-		248.5 \amp 4157.9 \\
-		\end{bmatrix}</m> and <m>A^T\bvec =
-		\twovec{1190.2}{19857.7}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\xhat = \twovec{\beta_0}{\beta_1} =
-		\twovec{22.8}{3.4}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>97.9</m> degrees.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <p>
@@ -1180,6 +1180,65 @@ print(df)
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		Use the fact that <m>\bhat=QQ^T\bvec</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Use the fact that <m>Q^TQ=I</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\beta_0 + 154\beta_1 + 68\beta_2 + 85\beta_3 +
+		17\beta_4 + 36\beta_5 = 13</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A</m> is the <m>10\times6</m> matrix whose columns
+		are a vector of all 1's followed by the vectors of
+		weights, heights, abdominal, wrist, and neck
+		measurements.  The vector <m>\bvec</m> is the vector
+		of BFI readings.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>Q</m> is a <m>10\times6</m> matrix and <m>R</m> is
+		a <m>6\times6</m> upper triangular matrix.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We find that
+		<md>
+		  \beta_0 = 54.08, \beta_1 = 0.19, \beta_2 =
+		    -2.62,
+		    \beta_3 = 0.92, \beta_4 = 2.70, \beta_5 =
+		    -0.41
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>R^2=0.95</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Evaluating <m>\beta_0 + 190\beta_1 + 70\beta_2 +
+		90\beta_3 + 18\beta_4 + 35\beta_5 = 22.9</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1245,65 +1304,6 @@ print(df)
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		Use the fact that <m>\bhat=QQ^T\bvec</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Use the fact that <m>Q^TQ=I</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\beta_0 + 154\beta_1 + 68\beta_2 + 85\beta_3 +
-		17\beta_4 + 36\beta_5 = 13</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A</m> is the <m>10\times6</m> matrix whose columns
-		are a vector of all 1's followed by the vectors of
-		weights, heights, abdominal, wrist, and neck
-		measurements.  The vector <m>\bvec</m> is the vector
-		of BFI readings.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>Q</m> is a <m>10\times6</m> matrix and <m>R</m> is
-		a <m>6\times6</m> upper triangular matrix.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We find that
-		<md>
-		  \beta_0 = 54.08, \beta_1 = 0.19, \beta_2 =
-		    -2.62,
-		    \beta_3 = 0.92, \beta_4 = 2.70, \beta_5 =
-		    -0.41
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>R^2=0.95</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Evaluating <m>\beta_0 + 190\beta_1 + 70\beta_2 +
-		90\beta_3 + 18\beta_4 + 35\beta_5 = 22.9</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
 
     </activity>
 
@@ -1481,6 +1481,68 @@ list_plot(data, color='blue', size=40) + plot( **your function here**,
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		We have the equations
+		<md>
+		  <mrow>
+		    \beta_0 + 0\beta_1 + 0^2\beta_2 \amp {}={} 2
+		  </mrow>
+		  <mrow>
+		    \beta_0 + 1\beta_1 + 1^2\beta_2 \amp {}={} 1
+		  </mrow>
+		  <mrow>
+		    \beta_0 + 2\beta_1 + 2^2\beta_2 \amp {}={} 3
+		  </mrow>
+		  <mrow>
+		    \beta_0 + 3\beta_1 + 3^2\beta_2 \amp {}={} 3
+		  </mrow>
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\xhat = \threevec{7/4}{-1/4}{1/4}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\frac74 - \frac14 x +
+		\frac14x^2 = y</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>1.9375</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>0.54</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>2-\frac{25}{6}x+4x^2-\frac56x^3 = y</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>R^2=1</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The graph of the cubic function passes through each
+		data point.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1552,68 +1614,6 @@ list_plot(data, color='blue', size=40) + plot( **your function here**,
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		We have the equations
-		<md>
-		  <mrow>
-		    \beta_0 + 0\beta_1 + 0^2\beta_2 \amp {}={} 2
-		  </mrow>
-		  <mrow>
-		    \beta_0 + 1\beta_1 + 1^2\beta_2 \amp {}={} 1
-		  </mrow>
-		  <mrow>
-		    \beta_0 + 2\beta_1 + 2^2\beta_2 \amp {}={} 3
-		  </mrow>
-		  <mrow>
-		    \beta_0 + 3\beta_1 + 3^2\beta_2 \amp {}={} 3
-		  </mrow>
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\xhat = \threevec{7/4}{-1/4}{1/4}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\frac74 - \frac14 x +
-		\frac14x^2 = y</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>1.9375</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>0.54</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>2-\frac{25}{6}x+4x^2-\frac56x^3 = y</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>R^2=1</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The graph of the cubic function passes through each
-		data point.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <p>
@@ -1795,6 +1795,46 @@ plot_model(xhat, data)
 	</p>
       </statement>
       
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>\xhat = \begin{bmatrix}
+		17.4\\-7.1\\4.5\\-1.1\\0.1\\-0.003
+		\end{bmatrix}
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The fifth degree polynomial fits the data fairly well.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>R^2=0.99</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>R^2=0.9997</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>R^2=1</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>8.7</m> million square kilometers
+		of sea ice.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1836,48 +1876,8 @@ plot_model(xhat, data)
 	  </ol>
 	</p>
       </solution>
-	    
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>\xhat = \begin{bmatrix}
-		17.4\\-7.1\\4.5\\-1.1\\0.1\\-0.003
-		\end{bmatrix}
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The fifth degree polynomial fits the data fairly well.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>R^2=0.99</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>R^2=0.9997</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>R^2=1</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>8.7</m> million square kilometers
-		of sea ice.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	    
+
+
     </activity>
 	
 

--- a/src/section7-1.xml
+++ b/src/section7-1.xml
@@ -551,6 +551,83 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      There is no such basis.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      There is no such basis.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      This matrix is diagonalizable with
+		      <md>
+			D = \begin{bmatrix}
+			2 \amp 0 \\
+			0 \amp 1 \\
+			\end{bmatrix},
+			\hspace{24pt}
+			P = \begin{bmatrix}
+			0 \amp 1 \\
+			1 \amp 1 \\
+			\end{bmatrix}\text{.}
+		      </md>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      This matrix is also diagonalizable with
+		      <md>
+			D = \begin{bmatrix}
+			10 \amp 0 \\
+			0 \amp 5 \\
+			\end{bmatrix},
+			\hspace{24pt}
+			P = \begin{bmatrix}
+			2 \amp 1 \\
+			1 \amp -2 \\
+			\end{bmatrix}\text{.}
+		      </md>
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Only the last matrix.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>Q = \begin{bmatrix}
+		2/\sqrt{5} \amp 1/\sqrt{5} \\
+		1/\sqrt{5} \amp -2/\sqrt{5} \\
+		\end{bmatrix}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>Q^{-1} =  Q^T</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A=A^T</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -643,84 +720,7 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      There is no such basis.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      There is no such basis.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      This matrix is diagonalizable with
-		      <md>
-			D = \begin{bmatrix}
-			2 \amp 0 \\
-			0 \amp 1 \\
-			\end{bmatrix},
-			\hspace{24pt}
-			P = \begin{bmatrix}
-			0 \amp 1 \\
-			1 \amp 1 \\
-			\end{bmatrix}\text{.}
-		      </md>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      This matrix is also diagonalizable with
-		      <md>
-			D = \begin{bmatrix}
-			10 \amp 0 \\
-			0 \amp 5 \\
-			\end{bmatrix},
-			\hspace{24pt}
-			P = \begin{bmatrix}
-			2 \amp 1 \\
-			1 \amp -2 \\
-			\end{bmatrix}\text{.}
-		      </md>
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Only the last matrix.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>Q = \begin{bmatrix}
-		2/\sqrt{5} \amp 1/\sqrt{5} \\
-		1/\sqrt{5} \amp -2/\sqrt{5} \\
-		\end{bmatrix}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>Q^{-1} =  Q^T</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A=A^T</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-			
+
     </activity>
 
     <p>
@@ -1053,6 +1053,79 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<md>
+		  D = \begin{bmatrix}
+		  4 \amp 0 \\
+		  0 \amp -1 \\
+		  \end{bmatrix},
+		  \hspace{24pt}
+		  Q = \begin{bmatrix}
+		  1/\sqrt{5} \amp 2/\sqrt{5} \\
+		  2/\sqrt{5} \amp -1/\sqrt{5} \\
+		  \end{bmatrix}\text{.}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  D = \begin{bmatrix}
+		  36 \amp 0 \amp 0 \\
+		  0 \amp 9 \amp 0 \\
+		  0 \amp 0 \amp -9 \\
+		  \end{bmatrix},
+		  \hspace{24pt}
+		  Q = \begin{bmatrix}
+		  1/3 \amp 2/3 \amp 2/3 \\
+		  -2/3 \amp 2/3 \amp -1/3 \\
+		  2/3 \amp 1/3 \amp -2/3 \\
+		  \end{bmatrix}\text{.}
+		</md>
+	      </p>
+	    </li>
+
+	    <li>
+	      <p>
+		<md>
+		  D = \begin{bmatrix}
+		  10 \amp 0 \amp 0 \\
+		  0 \amp 1 \amp 0 \\
+		  0 \amp 0 \amp 1 \\
+		  \end{bmatrix},
+		  \hspace{24pt}
+		  Q = \begin{bmatrix}
+		  2/3 \amp 1/\sqrt{5} \amp -4/\sqrt{45} \\
+		  2/3 \amp 0 \amp 5/\sqrt{45} \\
+		  1/3 \amp -2/\sqrt{5} \amp -2/\sqrt{45} \\
+		  \end{bmatrix}\text{.}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  D = \begin{bmatrix}
+		  7 \amp 0 \amp 0 \\
+		  0 \amp 3 \amp 0 \\
+		  0 \amp 0 \amp 0 \\
+		  \end{bmatrix},
+		  \hspace{24pt}
+		  Q = \begin{bmatrix}
+		  2/\sqrt{14} \amp 2/\sqrt{6} \amp 1/\sqrt{21} \\
+		  1/\sqrt{14} \amp -1/\sqrt{6} \amp 4/\sqrt{21} \\
+		  3/\sqrt{14} \amp -1/\sqrt{6} \amp -2/\sqrt{21} \\
+		  \end{bmatrix}\text{.}
+		</md>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1151,80 +1224,7 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<md>
-		  D = \begin{bmatrix}
-		  4 \amp 0 \\
-		  0 \amp -1 \\
-		  \end{bmatrix},
-		  \hspace{24pt}
-		  Q = \begin{bmatrix}
-		  1/\sqrt{5} \amp 2/\sqrt{5} \\
-		  2/\sqrt{5} \amp -1/\sqrt{5} \\
-		  \end{bmatrix}\text{.}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  D = \begin{bmatrix}
-		  36 \amp 0 \amp 0 \\
-		  0 \amp 9 \amp 0 \\
-		  0 \amp 0 \amp -9 \\
-		  \end{bmatrix},
-		  \hspace{24pt}
-		  Q = \begin{bmatrix}
-		  1/3 \amp 2/3 \amp 2/3 \\
-		  -2/3 \amp 2/3 \amp -1/3 \\
-		  2/3 \amp 1/3 \amp -2/3 \\
-		  \end{bmatrix}\text{.}
-		</md>
-	      </p>
-	    </li>
 
-	    <li>
-	      <p>
-		<md>
-		  D = \begin{bmatrix}
-		  10 \amp 0 \amp 0 \\
-		  0 \amp 1 \amp 0 \\
-		  0 \amp 0 \amp 1 \\
-		  \end{bmatrix},
-		  \hspace{24pt}
-		  Q = \begin{bmatrix}
-		  2/3 \amp 1/\sqrt{5} \amp -4/\sqrt{45} \\
-		  2/3 \amp 0 \amp 5/\sqrt{45} \\
-		  1/3 \amp -2/\sqrt{5} \amp -2/\sqrt{45} \\
-		  \end{bmatrix}\text{.}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  D = \begin{bmatrix}
-		  7 \amp 0 \amp 0 \\
-		  0 \amp 3 \amp 0 \\
-		  0 \amp 0 \amp 0 \\
-		  \end{bmatrix},
-		  \hspace{24pt}
-		  Q = \begin{bmatrix}
-		  2/\sqrt{14} \amp 2/\sqrt{6} \amp 1/\sqrt{21} \\
-		  1/\sqrt{14} \amp -1/\sqrt{6} \amp 4/\sqrt{21} \\
-		  3/\sqrt{14} \amp -1/\sqrt{6} \amp -2/\sqrt{21} \\
-		  \end{bmatrix}\text{.}
-		</md>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
     </activity>
 	  
     <p xml:id="p-spectral-summary">
@@ -1530,6 +1530,54 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>\overline{d} = \twovec22</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  \dtil_1=\twovec{-1}{-1},\hspace{24pt}
+		  \dtil_2=\twovec{0}{-1},\hspace{24pt}
+		  \dtil_3=\twovec{1}{2}\text{.}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V=8/3</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V_x = 2/3</m> and <m>V_y=2</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V=V_x+V_y</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V_{\vvec_1} = 7/3</m>
+	      </p>
+	      <p>
+		<m>V_{\vvec_2} = 1/3</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V = V_{\vvec_1} + V_{\vvec_2}</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1592,55 +1640,7 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>\overline{d} = \twovec22</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  \dtil_1=\twovec{-1}{-1},\hspace{24pt}
-		  \dtil_2=\twovec{0}{-1},\hspace{24pt}
-		  \dtil_3=\twovec{1}{2}\text{.}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V=8/3</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V_x = 2/3</m> and <m>V_y=2</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V=V_x+V_y</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V_{\vvec_1} = 7/3</m>
-	      </p>
-	      <p>
-		<m>V_{\vvec_2} = 1/3</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V = V_{\vvec_1} + V_{\vvec_2}</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
     </activity>
 
     <p>
@@ -1814,6 +1814,61 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>A^T\uvec=\threevec{\dtil_1\cdot\uvec}
+		{\dtil_2\cdot\uvec}
+		{\dtil_3\cdot\uvec}
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  V_{\uvec} = \frac13\left((\dtil_1\cdot\uvec)^2 +
+		  (\dtil_2\cdot\uvec)^2 + (\dtil_3\cdot\uvec)^2\right)
+		  = \frac13|A^T\uvec|^2\text{.}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<md>
+		  \frac13(A^T\uvec)\cdot(A^T\uvec) =
+		  \frac13\uvec\cdot(A^T)^TA^T\uvec =
+		  \uvec\cdot\left(\frac13AA^T\right)\uvec
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <m>C=\begin{bmatrix}
+	      2/3 \amp 1 \\
+	      1 \amp 2
+	      \end{bmatrix}
+	      </m>
+	    </li>
+	    <li>
+	      <p>
+		<m>V_{\uvec_1} = 38/15</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V_{\uvec_2} = 2/15</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>C^T = \left(\frac13 AA^T\right)^T = \frac13(A^T)^TA^T
+		= \frac13 AA^T = C</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1874,63 +1929,8 @@
 	  </ol>
 	</p>
       </solution>
-		
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>A^T\uvec=\threevec{\dtil_1\cdot\uvec}
-		{\dtil_2\cdot\uvec}
-		{\dtil_3\cdot\uvec}
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  V_{\uvec} = \frac13\left((\dtil_1\cdot\uvec)^2 +
-		  (\dtil_2\cdot\uvec)^2 + (\dtil_3\cdot\uvec)^2\right)
-		  = \frac13|A^T\uvec|^2\text{.}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<md>
-		  \frac13(A^T\uvec)\cdot(A^T\uvec) =
-		  \frac13\uvec\cdot(A^T)^TA^T\uvec =
-		  \uvec\cdot\left(\frac13AA^T\right)\uvec
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <m>C=\begin{bmatrix}
-	      2/3 \amp 1 \\
-	      1 \amp 2
-	      \end{bmatrix}
-	      </m>
-	    </li>
-	    <li>
-	      <p>
-		<m>V_{\uvec_1} = 38/15</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V_{\uvec_2} = 2/15</m>.  
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>C^T = \left(\frac13 AA^T\right)^T = \frac13(A^T)^TA^T
-		= \frac13 AA^T = C</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
+
     </activity>
 
     <p>
@@ -2048,6 +2048,49 @@ list_plot(data, size=20, color='blue', aspect_ratio=1)
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>C=\begin{bmatrix}
+		1.38 \amp 0.70 \\
+		0.70 \amp 0.37
+		\end{bmatrix}
+		</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V_x = 1.38</m> and <m>V_y=0.37</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V=1.75</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		If <m>\uvec_1=\twovec{2/\sqrt{5}}{1/\sqrt{5}}</m>,
+		then <m>V_{\uvec_1} = 1.74</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		If <m>\uvec_2=\twovec{-1/\sqrt{5}}{2/\sqrt{5}}</m>,
+		then <m>V_{\uvec_2} = 0.01</m>.
+
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		They are orthogonal to one another.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -2103,49 +2146,6 @@ list_plot(data, size=20, color='blue', aspect_ratio=1)
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>C=\begin{bmatrix}
-		1.38 \amp 0.70 \\
-		0.70 \amp 0.37
-		\end{bmatrix}
-		</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V_x = 1.38</m> and <m>V_y=0.37</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V=1.75</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		If <m>\uvec_1=\twovec{2/\sqrt{5}}{1/\sqrt{5}}</m>,
-		then <m>V_{\uvec_1} = 1.74</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		If <m>\uvec_2=\twovec{-1/\sqrt{5}}{2/\sqrt{5}}</m>,
-		then <m>V_{\uvec_2} = 0.01</m>.
-
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		They are orthogonal to one another.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
 
     </activity>
 

--- a/src/section7-2.xml
+++ b/src/section7-2.xml
@@ -300,6 +300,43 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>q_D(\xvec) = 3x_1^2 - x_2^2</m> and
+		<m>q_D\left(\twovec2{-4}\right) = -4</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>q_A(\xvec) = 2x_1^2 + 10x_1x_2-3x_2^2</m> and
+		<m>q_A\left(\twovec2{-1}\right) = -15</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A=\begin{bmatrix}
+		3 \amp -2 \\
+		-2 \amp 4 \\
+		\end{bmatrix}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>q(2\xvec) = 12</m>,
+		<m>q(-\xvec) = 3</m> and <m>q(10\xvec)=300</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>q_A(\xvec) = -196</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -340,45 +377,8 @@
 	  </ol>
 	</p>
       </solution>
-	      
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>q_D(\xvec) = 3x_1^2 - x_2^2</m> and
-		<m>q_D\left(\twovec2{-4}\right) = -4</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>q_A(\xvec) = 2x_1^2 + 10x_1x_2-3x_2^2</m> and 
-		<m>q_A\left(\twovec2{-1}\right) = -15</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A=\begin{bmatrix}
-		3 \amp -2 \\
-		-2 \amp 4 \\
-		\end{bmatrix}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>q(2\xvec) = 12</m>, 
-		<m>q(-\xvec) = 3</m> and <m>q(10\xvec)=300</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>q_A(\xvec) = -196</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	      
+
+
     </activity>
 
     <p>
@@ -587,6 +587,66 @@ quad_plot(A)
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		The maximum appears to occur in the direction of
+		<m>\twovec10</m> and the minimum appears to occur in
+		the direction of <m>\twovec01</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>q_D(\xvec) = 3x_1^2 - x_2^2</m> so that
+		<m>q_D\left(\twovec10\right) = 3</m> and
+		<m>q_D\left(\twovec01\right) = -1</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The maximum value of
+		<m>q_D(\uvec)</m> is <m>3</m> in the direction
+		<m>\twovec10</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The minimum value of
+		<m>q_D(\uvec)</m> is <m>-1</m> in the direction
+		<m>\twovec01</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The maximum appears to occur in the
+		direction <m>\twovec11</m> and the minimum in the
+		direction <m>\twovec{-1}1</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Use the fact that <m>QQ^T=I</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The maximum of
+		<m>q_A(\uvec)</m> is <m>3</m>, which occurs when
+		<m>\uvec=
+		\twovec{1/\sqrt{2}}{1/\sqrt{2}}</m>.
+	      </p>
+	      <p>
+		The maximum of
+		<m>q_A(\uvec)</m> is <m>-1</m>, which occurs when
+		<m>\uvec=
+		\twovec{-1/\sqrt{2}}{1/\sqrt{2}}</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -664,66 +724,6 @@ quad_plot(A)
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		The maximum appears to occur in the direction of
-		<m>\twovec10</m> and the minimum appears to occur in
-		the direction of <m>\twovec01</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>q_D(\xvec) = 3x_1^2 - x_2^2</m> so that
-		<m>q_D\left(\twovec10\right) = 3</m> and 
-		<m>q_D\left(\twovec01\right) = -1</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The maximum value of
-		<m>q_D(\uvec)</m> is <m>3</m> in the direction
-		<m>\twovec10</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The minimum value of
-		<m>q_D(\uvec)</m> is <m>-1</m> in the direction
-		<m>\twovec01</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The maximum appears to occur in the
-		direction <m>\twovec11</m> and the minimum in the
-		direction <m>\twovec{-1}1</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Use the fact that <m>QQ^T=I</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The maximum of
-		<m>q_A(\uvec)</m> is <m>3</m>, which occurs when
-		<m>\uvec=
-		\twovec{1/\sqrt{2}}{1/\sqrt{2}}</m>.
-	      </p>
-	      <p>
-		The maximum of
-		<m>q_A(\uvec)</m> is <m>-1</m>, which occurs when
-		<m>\uvec=
-		\twovec{-1/\sqrt{2}}{1/\sqrt{2}}</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <p>
@@ -1179,6 +1179,71 @@ quad_plot(A)
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>q_D(\xvec) = 4x_1^2 + 2x_2^2</m>
+		so <m>D</m> is positive definite.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>q_D(\xvec) = 4x_1^2</m>
+		so <m>D</m> is positive semidefinite.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      They are all positive.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      They are all nonnegative.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      They are all negative.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      They are all nonpositive.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      They are some positive eigenvalues and some
+		      negative ones .
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A</m> is positive definite.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A</m> is positive semidefinite.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		They will be the same as before.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1251,73 +1316,8 @@ quad_plot(A)
 	  </ol>
 	</p>
       </solution>
-		      
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>q_D(\xvec) = 4x_1^2 + 2x_2^2</m>
-		so <m>D</m> is positive definite.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>q_D(\xvec) = 4x_1^2</m>
-		so <m>D</m> is positive semidefinite.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      They are all positive.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      They are all nonnegative.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      They are all negative. 
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      They are all nonpositive.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      They are some positive eigenvalues and some
-		      negative ones .
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A</m> is positive definite.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A</m> is positive semidefinite.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		They will be the same as before.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		      
+
+
     </activity>
 
     <p>
@@ -1480,6 +1480,68 @@ plot3d(2*x^3 - 6*x*y + 3*y^2, (x, 0.75,1.25), (y,0.75,1.25))
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		We have
+		<md>
+		  <mrow>
+		    f_x \amp {}={} 6x^2 - 6y = 0
+		  </mrow>
+		  <mrow>
+		    f_y \amp {}={} -6x + 6y = 0
+		  </mrow>
+                </md>
+		with critical points
+		<m>(0,0)</m> and <m>(1,1)</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We have
+		<md>
+		  f_{xx} = 12x, \hspace{24pt}
+		  f_{xy} = -6, \hspace{24pt}
+		  f_{yy} = 6
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		This gives
+		<md>
+		  f(x,y)\approx -1 + \frac12 12(x-1)^2 -6(x-1)(y-1) +
+		  \frac12 6(y-1)^2
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A = \begin{bmatrix}
+		6 \amp -3 \\
+		-3 \amp 3
+		\end{bmatrix}
+		</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A</m> is positive definite.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>
+		  f(x,y) \approx f(1,1) + q_A(\wvec) \gt f(1,1)
+		</m>
+		for points <m>(x,y)</m> near to <m>(1,1)</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1547,70 +1609,8 @@ plot3d(2*x^3 - 6*x*y + 3*y^2, (x, 0.75,1.25), (y,0.75,1.25))
 	  </ol>
 	</p>
       </solution>
-	  
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		We have
-		<md>
-		  <mrow>
-		    f_x \amp {}={} 6x^2 - 6y = 0
-		  </mrow>
-		  <mrow>
-		    f_y \amp {}={} -6x + 6y = 0
-		  </mrow>
-                </md>
-		with critical points
-		<m>(0,0)</m> and <m>(1,1)</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We have
-		<md>
-		  f_{xx} = 12x, \hspace{24pt}
-		  f_{xy} = -6, \hspace{24pt}
-		  f_{yy} = 6
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		This gives
-		<md>
-		  f(x,y)\approx -1 + \frac12 12(x-1)^2 -6(x-1)(y-1) +
-		  \frac12 6(y-1)^2
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A = \begin{bmatrix}
-		6 \amp -3 \\
-		-3 \amp 3
-		\end{bmatrix}
-		</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A</m> is positive definite.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>
-		  f(x,y) \approx f(1,1) + q_A(\wvec) \gt f(1,1)
-		</m>
-		for points <m>(x,y)</m> near to <m>(1,1)</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	      
+
+
     </activity>
 
     <p>

--- a/src/section7-3.xml
+++ b/src/section7-3.xml
@@ -283,6 +283,46 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>10</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>0</m>, which tells us
+		every data point is in the
+		orthogonal complement of <m>\uvec_4</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>25</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>92\%</m> of the variance
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>100\%</m> of the variance.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		All of the data lies in the <m>3</m>-dimensional
+		subspace spanned by
+		<m>\uvec_1</m>, <m>\uvec_1</m>, and <m>\uvec_1</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -330,48 +370,8 @@
 	  </ol>
 	</p>
       </solution>
-      
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>10</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>0</m>, which tells us
-		every data point is in the
-		orthogonal complement of <m>\uvec_4</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>25</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>92\%</m> of the variance
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>100\%</m> of the variance.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		All of the data lies in the <m>3</m>-dimensional
-		subspace spanned by
-		<m>\uvec_1</m>, <m>\uvec_1</m>, and <m>\uvec_1</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	  
+
+
     </activity>
 
     <p>
@@ -576,6 +576,47 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>V_{\uvec} = 7885</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V=12195</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		If <m>P</m> is the matrix of eigenvectors, evaluate
+		<m>P^TP</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>W_1</m> retains
+		<m>83\%</m> of the total variance, and
+		<m>W_2</m> retains <m>98\%</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>Q=\begin{bmatrix}\uvec_1\amp\uvec_2\end{bmatrix}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Because the variance in the <m>\uvec_1</m> direction
+		is greater than the variance in the <m>\uvec_2</m>
+		direction.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -628,47 +669,6 @@ sage.repl.load.load('https://raw.githubusercontent.com/davidaustinm/ula_modules/
 	  </ol>
 	</p>
       </solution>
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>V_{\uvec} = 7885</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V=12195</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		If <m>P</m> is the matrix of eigenvectors, evaluate
-		<m>P^TP</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>W_1</m> retains 
-		<m>83\%</m> of the total variance, and 
-		<m>W_2</m> retains <m>98\%</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>Q=\begin{bmatrix}\uvec_1\amp\uvec_2\end{bmatrix}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Because the variance in the <m>\uvec_1</m> direction
-		is greater than the variance in the <m>\uvec_2</m>
-		direction.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <p>
@@ -947,6 +947,105 @@ df
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>57.5</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>78805</m>,
+		<m>33946</m>, and <m>4093</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>67\%</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The coordinates are
+              </p>
+		<table>
+		  <tabular halign="right">
+		    <row bottom="minor">
+		      <cell> Nation </cell>
+		      <cell> Coordinate </cell>
+		    </row>
+		    <row>
+		      <cell> England </cell>
+		      <cell> <m>-145</m> </cell>
+		    </row>
+		    <row>
+		      <cell> Northern Ireland </cell>
+		      <cell> <m>477</m> </cell>
+		    </row>
+		    <row>
+		      <cell> Scotland </cell>
+		      <cell> <m>-92</m> </cell>
+		    </row>
+		    <row>
+		      <cell> Wales </cell>
+		      <cell> <m>-241</m> </cell>
+		    </row>
+		  </tabular>
+		</table>
+	    </li>
+
+	    <li>
+	      <p>
+		<m>96\%</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The coordinates are
+              </p>
+		<table>
+		  <tabular halign="right">
+		    <row bottom="minor">
+		      <cell> Nation </cell>
+		      <cell> Coordinates </cell>
+		    </row>
+		    <row>
+		      <cell> England </cell>
+		      <cell> <m>(-145, 3)</m> </cell>
+		    </row>
+		    <row>
+		      <cell> Northern Ireland </cell>
+		      <cell> <m>(477, 59)</m> </cell>
+		    </row>
+		    <row>
+		      <cell> Scotland </cell>
+		      <cell> <m>(-92, -286)</m> </cell>
+		    </row>
+		    <row>
+		      <cell> England </cell>
+		      <cell> <m>(-241, 225)</m> </cell>
+		    </row>
+		  </tabular>
+		</table>
+	    </li>
+
+	    <li>
+	      <p>
+		Northern Ireland appears to be significantly different
+		from the other three nations.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The average consumption of Alcoholic Drinks will
+		be less than the mean.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1059,105 +1158,6 @@ df
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>57.5</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>78805</m>,
-		<m>33946</m>, and <m>4093</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>67\%</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The coordinates are
-              </p>
-		<table>
-		  <tabular halign="right">
-		    <row bottom="minor">
-		      <cell> Nation </cell>
-		      <cell> Coordinate </cell>
-		    </row>
-		    <row>
-		      <cell> England </cell>
-		      <cell> <m>-145</m> </cell>
-		    </row>
-		    <row>
-		      <cell> Northern Ireland </cell>
-		      <cell> <m>477</m> </cell>
-		    </row>
-		    <row>
-		      <cell> Scotland </cell>
-		      <cell> <m>-92</m> </cell>
-		    </row>
-		    <row>
-		      <cell> Wales </cell>
-		      <cell> <m>-241</m> </cell>
-		    </row>
-		  </tabular>
-		</table>
-	    </li>
-
-	    <li>
-	      <p>
-		<m>96\%</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The coordinates are
-              </p>
-		<table>
-		  <tabular halign="right">
-		    <row bottom="minor">
-		      <cell> Nation </cell>
-		      <cell> Coordinates </cell>
-		    </row>
-		    <row>
-		      <cell> England </cell>
-		      <cell> <m>(-145, 3)</m> </cell>
-		    </row>
-		    <row>
-		      <cell> Northern Ireland </cell>
-		      <cell> <m>(477, 59)</m> </cell>
-		    </row>
-		    <row>
-		      <cell> Scotland </cell>
-		      <cell> <m>(-92, -286)</m> </cell>
-		    </row>
-		    <row>
-		      <cell> England </cell>
-		      <cell> <m>(-241, 225)</m> </cell>
-		    </row>
-		  </tabular>
-		</table>
-	    </li>
-
-	    <li>
-	      <p>
-		Northern Ireland appears to be significantly different
-		from the other three nations.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The average consumption of Alcoholic Drinks will
-		be less than the mean.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
     </activity>
 
     <p>
@@ -1370,6 +1370,52 @@ pca_plot(Q.T*A)
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>3.05</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>4.20</m>, <m>0.24</m>,
+		<m>0.08</m>, <m>0.02</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>97.8\%</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The columns of <m>Q</m> are for the first two
+		principal components.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Iris setosa and the vector of measurements is
+		<m>\fourvec{5.43}{3.81}{1.49}{0.25}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The petal length is
+		<m>3.99</m> and the petal width is <m>1.29</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The sepal length is <m>7.23</m> and the petal length
+		is <m>6.15</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1433,53 +1479,7 @@ pca_plot(Q.T*A)
 	  </ol>
 	</p>
       </solution>
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>3.05</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>4.20</m>, <m>0.24</m>,
-		<m>0.08</m>, <m>0.02</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>97.8\%</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The columns of <m>Q</m> are for the first two
-		principal components.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Iris setosa and the vector of measurements is
-		<m>\fourvec{5.43}{3.81}{1.49}{0.25}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The petal length is
-		<m>3.99</m> and the petal width is <m>1.29</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The sepal length is <m>7.23</m> and the petal length
-		is <m>6.15</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
     </activity>
       
 

--- a/src/section7-4.xml
+++ b/src/section7-4.xml
@@ -453,6 +453,67 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>\sigma_1=3</m>, <m>\vvec_1 =
+		\twovec{1/\sqrt{2}}{1/\sqrt{2}}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\sigma_2=1</m>, <m>\vvec_1 =
+		\twovec{1/\sqrt{2}}{-1/\sqrt{2}}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The maximum value of <m>q_G(\xvec)</m> is
+		<m>9</m>, which occurs in the direction
+		<m>\twovec{1/\sqrt{2}}{1/\sqrt{2}}</m>.  The minimum
+		value of <m>q_G(\xvec)</m> is <m>1</m>, which
+		occurs in the direction
+		<m>\twovec{1/\sqrt{2}}{-1/\sqrt{2}}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\sigma_1 = \sqrt{9} = 3</m>
+		and <m>\sigma_2 = \sqrt{1}
+		= 1</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\vvec_1</m> agrees with the direction in which
+		<m>q_G(\xvec)</m> has its maximum value.  The
+		corresponding fact is true for <m>\vvec_2</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\uvec_1=\twovec{1/\sqrt{2}}{-1/\sqrt{2}}</m> and
+		<m>\uvec_2 = \twovec{-1/\sqrt{2}}{-1/\sqrt{2}}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>AV = \begin{bmatrix} A\vvec_1 \amp A\vvec_2
+		\end{bmatrix} = \begin{bmatrix} \sigma_1\uvec_1 \amp
+		\sigma_2\uvec_2 \end{bmatrix} = U\Sigma</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Since <m>V</m> is an orthogonal matrix, we have
+		<m>A = AVV^T = U\Sigma V^T</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -533,68 +594,7 @@
 	  </ol>
 	</p>
       </solution>
-		  
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>\sigma_1=3</m>, <m>\vvec_1 =
-		\twovec{1/\sqrt{2}}{1/\sqrt{2}}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\sigma_2=1</m>, <m>\vvec_1 =
-		\twovec{1/\sqrt{2}}{-1/\sqrt{2}}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The maximum value of <m>q_G(\xvec)</m> is 
-		<m>9</m>, which occurs in the direction 
-		<m>\twovec{1/\sqrt{2}}{1/\sqrt{2}}</m>.  The minimum
-		value of <m>q_G(\xvec)</m> is <m>1</m>, which
-		occurs in the direction 
-		<m>\twovec{1/\sqrt{2}}{-1/\sqrt{2}}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\sigma_1 = \sqrt{9} = 3</m>
-		and <m>\sigma_2 = \sqrt{1}
-		= 1</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\vvec_1</m> agrees with the direction in which
-		<m>q_G(\xvec)</m> has its maximum value.  The
-		corresponding fact is true for <m>\vvec_2</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\uvec_1=\twovec{1/\sqrt{2}}{-1/\sqrt{2}}</m> and
-		<m>\uvec_2 = \twovec{-1/\sqrt{2}}{-1/\sqrt{2}}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>AV = \begin{bmatrix} A\vvec_1 \amp A\vvec_2
-		\end{bmatrix} = \begin{bmatrix} \sigma_1\uvec_1 \amp
-		\sigma_2\uvec_2 \end{bmatrix} = U\Sigma</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Since <m>V</m> is an orthogonal matrix, we have
-		<m>A = AVV^T = U\Sigma V^T</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
+
     </activity>
 		  
     <p>
@@ -950,6 +950,74 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>G</m> can be orthogonally diagaonalized with
+		<md>
+		  D = \begin{bmatrix}
+		  3 \amp 0 \amp 0 \\
+		  0 \amp 2 \amp 0 \\
+		  0 \amp 0 \amp 0
+		  \end{bmatrix},\hspace{24pt}
+		  Q = \begin{bmatrix}
+		  1/\sqrt{3} \amp 1/\sqrt{2} \amp 1/\sqrt{6} \\
+		  1/\sqrt{3} \amp 0 \amp -2/\sqrt{6} \\
+		  1/\sqrt{3} \amp -1/\sqrt{2} \amp 1/\sqrt{6}
+		  \end{bmatrix}.
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\sigma_1 = \sqrt{3}</m>,
+		<m>\sigma_2 = \sqrt{2}</m>, and <m>\sigma_3 = 0</m>.
+		The three right singular vectors <m>\vvec_i</m> are
+		the columns of <m>Q</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\uvec_1 = \twovec01</m> and <m>\uvec_2 = \twovec10</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We have
+		<md>
+		  U = \begin{bmatrix}
+		  0 \amp 1 \\
+		  1 \amp 0 \\
+		  \end{bmatrix},\hspace{24pt}
+		  V = \begin{bmatrix}
+		  1/\sqrt{3} \amp 1/\sqrt{2} \amp 1/\sqrt{6} \\
+		  1/\sqrt{3} \amp 0 \amp -2/\sqrt{6} \\
+		  1/\sqrt{3} \amp -1/\sqrt{2} \amp 1/\sqrt{6}
+		  \end{bmatrix}\text{.}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		With <m>
+		\Sigma = \begin{bmatrix}
+		\sqrt{3} \amp 0 \amp 0 \\
+		0 \amp \sqrt{2} \amp 0
+		\end{bmatrix}</m>, we see that <m>A=U\Sigma V^T</m>.
+	      </p>
+	    </li>
+
+	    <li>
+	      <p>
+		<m>A^T=(U\Sigma V^T)^T
+		= V\Sigma^T U^T</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1051,76 +1119,8 @@
 	  </ol>
 	</p>
       </solution>
-		
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>G</m> can be orthogonally diagaonalized with
-		<md>
-		  D = \begin{bmatrix}
-		  3 \amp 0 \amp 0 \\
-		  0 \amp 2 \amp 0 \\
-		  0 \amp 0 \amp 0
-		  \end{bmatrix},\hspace{24pt}
-		  Q = \begin{bmatrix}
-		  1/\sqrt{3} \amp 1/\sqrt{2} \amp 1/\sqrt{6} \\
-		  1/\sqrt{3} \amp 0 \amp -2/\sqrt{6} \\
-		  1/\sqrt{3} \amp -1/\sqrt{2} \amp 1/\sqrt{6} 
-		  \end{bmatrix}.
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\sigma_1 = \sqrt{3}</m>,
-		<m>\sigma_2 = \sqrt{2}</m>, and <m>\sigma_3 = 0</m>.
-		The three right singular vectors <m>\vvec_i</m> are
-		the columns of <m>Q</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\uvec_1 = \twovec01</m> and <m>\uvec_2 = \twovec10</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We have
-		<md>
-		  U = \begin{bmatrix}
-		  0 \amp 1 \\
-		  1 \amp 0 \\
-		  \end{bmatrix},\hspace{24pt}
-		  V = \begin{bmatrix}
-		  1/\sqrt{3} \amp 1/\sqrt{2} \amp 1/\sqrt{6} \\
-		  1/\sqrt{3} \amp 0 \amp -2/\sqrt{6} \\
-		  1/\sqrt{3} \amp -1/\sqrt{2} \amp 1/\sqrt{6} 
-		  \end{bmatrix}\text{.}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		With <m>
-		\Sigma = \begin{bmatrix}
-		\sqrt{3} \amp 0 \amp 0 \\
-		0 \amp \sqrt{2} \amp 0
-		\end{bmatrix}</m>, we see that <m>A=U\Sigma V^T</m>.
-	      </p>
-	    </li>
 
-	    <li>
-	      <p>
-		<m>A^T=(U\Sigma V^T)^T
-		= V\Sigma^T U^T</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		
+
     </activity>
 
     <example xml:id="example-svd-nonsquare">
@@ -1403,6 +1403,46 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>A</m> is <m>4\times3</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>c_1 = 2</m>, <m>c_2 = 4</m>, and there is no
+		condition on <m>c_3</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>c_1 = 0</m>, <m>c_2 = 0</m>, and there is no
+		condition on <m>c_3</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\vvec_3</m> forms a basis for <m>\nul(A)</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\uvec_1</m> and
+		<m>\uvec_2</m> form a basis for <m>\col(A)</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\rank(A) = 2</m>, which is the number of nonzero
+		singular values.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1456,46 +1496,6 @@
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>A</m> is <m>4\times3</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>c_1 = 2</m>, <m>c_2 = 4</m>, and there is no
-		condition on <m>c_3</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>c_1 = 0</m>, <m>c_2 = 0</m>, and there is no
-		condition on <m>c_3</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\vvec_3</m> forms a basis for <m>\nul(A)</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\uvec_1</m> and
-		<m>\uvec_2</m> form a basis for <m>\col(A)</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\rank(A) = 2</m>, which is the number of nonzero
-		singular values.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
 
     </activity>
 
@@ -1833,6 +1833,84 @@
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>A</m> is a <m>4\times3</m> matrix and <m>\rank(A) =
+		2</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\uvec_1</m> and <m>\uvec_2</m> form an orthonormal
+		basis for <m>\col(A)</m>, and <m>\vvec_1</m> and
+		<m>\vvec_2</m> form an orthonormal
+		basis for <m>\nul(A)</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Notice that
+		<md>
+		  U\Sigma =
+		  \begin{bmatrix}
+		  \uvec_1 \amp \uvec_2 \amp \uvec_3 \amp \uvec_4
+		  \end{bmatrix}
+		  \begin{bmatrix}
+		  18 \amp 0 \amp 0 \\
+		  0 \amp 4 \amp 0 \\
+		  0 \amp 0 \amp 0 \\
+		  0 \amp 0 \amp 0
+		  \end{bmatrix}
+		  = \begin{bmatrix}
+		  18\uvec_1 \amp 4\uvec_2 \amp \zerovec
+		  \end{bmatrix}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Notice that
+		<md>
+		  \begin{bmatrix}
+		  18 \amp 0 \amp 0 \\
+		  0 \amp 4 \amp 0 \\
+		  \end{bmatrix}V^T =
+		  \begin{bmatrix}
+		  18 \amp 0 \amp 0 \\
+		  0 \amp 4 \amp 0 \\
+		  \end{bmatrix}
+		  \begin{bmatrix}
+		  \vvec_1^T \\
+		  \vvec_2^T \\
+		  \vvec_3^T
+		  \end{bmatrix}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Put together the previous parts to see that
+		<m>A=U_r\Sigma_rV_r^T</m> where
+		<md>
+		  U_r = \begin{bmatrix}
+		  \uvec_1 \amp \uvec_2
+		  \end{bmatrix},\hspace{24pt}
+		  \Sigma_r = \begin{bmatrix}
+		  18 \amp 0 \\
+		  0 \amp 4 \\
+		  \end{bmatrix},\hspace{24pt}
+		  V_r = \begin{bmatrix}
+		  \vvec_1 \amp \vvec_2
+		  \end{bmatrix}\text{.}
+		</md>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1929,86 +2007,8 @@
 	  </ol>
 	</p>
       </solution>
-      
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>A</m> is a <m>4\times3</m> matrix and <m>\rank(A) =
-		2</m> 
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\uvec_1</m> and <m>\uvec_2</m> form an orthonormal
-		basis for <m>\col(A)</m>, and <m>\vvec_1</m> and
-		<m>\vvec_2</m> form an orthonormal
-		basis for <m>\nul(A)</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Notice that
-		<md>
-		  U\Sigma =
-		  \begin{bmatrix}
-		  \uvec_1 \amp \uvec_2 \amp \uvec_3 \amp \uvec_4
-		  \end{bmatrix}
-		  \begin{bmatrix}
-		  18 \amp 0 \amp 0 \\
-		  0 \amp 4 \amp 0 \\
-		  0 \amp 0 \amp 0 \\
-		  0 \amp 0 \amp 0
-		  \end{bmatrix}
-		  = \begin{bmatrix}
-		  18\uvec_1 \amp 4\uvec_2 \amp \zerovec
-		  \end{bmatrix} 
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Notice that
-		<md>
-		  \begin{bmatrix}
-		  18 \amp 0 \amp 0 \\
-		  0 \amp 4 \amp 0 \\
-		  \end{bmatrix}V^T =
-		  \begin{bmatrix}
-		  18 \amp 0 \amp 0 \\
-		  0 \amp 4 \amp 0 \\
-		  \end{bmatrix}
-		  \begin{bmatrix}
-		  \vvec_1^T \\
-		  \vvec_2^T \\
-		  \vvec_3^T
-		  \end{bmatrix} 
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Put together the previous parts to see that
-		<m>A=U_r\Sigma_rV_r^T</m> where
-		<md>
-		  U_r = \begin{bmatrix}
-		  \uvec_1 \amp \uvec_2
-		  \end{bmatrix},\hspace{24pt}
-		  \Sigma_r = \begin{bmatrix}
-		  18 \amp 0 \\
-		  0 \amp 4 \\
-		  \end{bmatrix},\hspace{24pt}
-		  V_r = \begin{bmatrix}
-		  \vvec_1 \amp \vvec_2
-		  \end{bmatrix}\text{.}
-		</md>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		  
+
+
     </activity>
 
     <p>

--- a/src/section7-5.xml
+++ b/src/section7-5.xml
@@ -314,6 +314,65 @@ print(V)
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>\sigma_1 = 2.67</m> and
+		<m>\sigma_2 = 0.92</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\rank(A) = 2</m> and the first two columns of
+		<m>U</m> form an orthonormal basis for <m>\col(A)</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We have
+		<md>
+		  U_r = \begin{bmatrix}
+		  -0.22 \amp 0.89 \\
+		  -0.52 \amp 0.25 \\
+		  -0.83 \amp -0.39
+		  \end{bmatrix},\hspace{24pt}
+		  \Sigma_r = \begin{bmatrix}
+		  2.7 \amp 0.00 \\
+		  0.00 \amp 0.92
+		  \end{bmatrix},\hspace{24pt}
+		  V_r = \begin{bmatrix}
+		  -0.58 \amp 0.81 \\
+		  -0.81 \amp -0.58
+		  \end{bmatrix}\text{.}
+		</md>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The columns of <m>U_r</m> form an orthonormal basis
+		for <m>\col(A)</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\bhat=U_rU_r^T\bvec</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>V_r^TV_r = I</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\xhat=\twovec{-0.83}{3.50}</m>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -388,66 +447,7 @@ print(V)
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>\sigma_1 = 2.67</m> and
-		<m>\sigma_2 = 0.92</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\rank(A) = 2</m> and the first two columns of
-		<m>U</m> form an orthonormal basis for <m>\col(A)</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We have
-		<md>
-		  U_r = \begin{bmatrix}
-		  -0.22 \amp 0.89 \\
-		  -0.52 \amp 0.25 \\
-		  -0.83 \amp -0.39
-		  \end{bmatrix},\hspace{24pt}
-		  \Sigma_r = \begin{bmatrix}
-		  2.7 \amp 0.00 \\
-		  0.00 \amp 0.92
-		  \end{bmatrix},\hspace{24pt}
-		  V_r = \begin{bmatrix}
-		  -0.58 \amp 0.81 \\
-		  -0.81 \amp -0.58
-		  \end{bmatrix}\text{.}
-		</md>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The columns of <m>U_r</m> form an orthonormal basis
-		for <m>\col(A)</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\bhat=U_rU_r^T\bvec</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>V_r^TV_r = I</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\xhat=\twovec{-0.83}{3.50}</m>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	      
+
     </activity>
 		
     <p>
@@ -646,6 +646,84 @@ Sigma = diagonal_matrix([500, 100, 20, 4])
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<m>A = \begin{bmatrix}
+		156 \amp 96 \amp -144 \amp -104 \\
+		144 \amp 104 \amp -156 \amp -96 \\
+		104 \amp 144 \amp -96 \amp -156 \\
+		96 \amp 156 \amp -104 \amp -144
+		\end{bmatrix}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A_1=\begin{bmatrix}
+		125 \amp 125 \amp -125 \amp -125 \\
+		125 \amp 125 \amp -125 \amp -125 \\
+		125 \amp 125 \amp -125 \amp -125 \\
+		125 \amp 125 \amp -125 \amp -125
+		\end{bmatrix}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A-A_1 = \begin{bmatrix}
+		31 \amp -29 \amp -19 \amp 21 \\
+		19 \amp -21 \amp -31 \amp 29 \\
+		-21 \amp 19 \amp 29 \amp -31 \\
+		-29 \amp 31 \amp 21 \amp -19
+		\end{bmatrix}</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A_2 = \begin{bmatrix}
+		150 \amp 100 \amp -150 \amp -100 \\
+		150 \amp 100 \amp -150 \amp -100 \\
+		100 \amp 150 \amp -100 \amp -150 \\
+		100 \amp 150 \amp -100 \amp -150
+		\end{bmatrix}</m>
+		and <m>A-A_2 = \begin{bmatrix}
+		6 \amp -4 \amp 6 \amp -4 \\
+		-6 \amp 4 \amp -6 \amp 4 \\
+		4 \amp -6 \amp 4 \amp -6 \\
+		-4 \amp 6 \amp -4 \amp 6
+		\end{bmatrix}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A_3 = \begin{bmatrix}
+		155 \amp 95 \amp -145 \amp -105 \\
+		145 \amp 105 \amp -155 \amp -95 \\
+		105 \amp 145 \amp -95 \amp -155 \\
+		95 \amp 155 \amp -105 \amp -145
+		\end{bmatrix}</m> and
+		<m>A-A_3 = \begin{bmatrix}
+		1 \amp 1 \amp 1 \amp 1 \\
+		-1 \amp -1 \amp -1 \amp -1 \\
+		-1 \amp -1 \amp -1 \amp -1 \\
+		1 \amp 1 \amp 1 \amp 1
+		\end{bmatrix}</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>A_4=A</m>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The entries get closer to <m>0</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -733,85 +811,7 @@ Sigma = diagonal_matrix([500, 100, 20, 4])
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<m>A = \begin{bmatrix}
-		156 \amp 96 \amp -144 \amp -104 \\
-		144 \amp 104 \amp -156 \amp -96 \\
-		104 \amp 144 \amp -96 \amp -156 \\
-		96 \amp 156 \amp -104 \amp -144
-		\end{bmatrix}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A_1=\begin{bmatrix}
-		125 \amp 125 \amp -125 \amp -125 \\
-		125 \amp 125 \amp -125 \amp -125 \\
-		125 \amp 125 \amp -125 \amp -125 \\
-		125 \amp 125 \amp -125 \amp -125
-		\end{bmatrix}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A-A_1 = \begin{bmatrix}
-		31 \amp -29 \amp -19 \amp 21 \\
-		19 \amp -21 \amp -31 \amp 29 \\
-		-21 \amp 19 \amp 29 \amp -31 \\
-		-29 \amp 31 \amp 21 \amp -19
-		\end{bmatrix}</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A_2 = \begin{bmatrix}
-		150 \amp 100 \amp -150 \amp -100 \\
-		150 \amp 100 \amp -150 \amp -100 \\
-		100 \amp 150 \amp -100 \amp -150 \\
-		100 \amp 150 \amp -100 \amp -150
-		\end{bmatrix}</m>
-		and <m>A-A_2 = \begin{bmatrix}
-		6 \amp -4 \amp 6 \amp -4 \\
-		-6 \amp 4 \amp -6 \amp 4 \\
-		4 \amp -6 \amp 4 \amp -6 \\
-		-4 \amp 6 \amp -4 \amp 6
-		\end{bmatrix}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A_3 = \begin{bmatrix}
-		155 \amp 95 \amp -145 \amp -105 \\
-		145 \amp 105 \amp -155 \amp -95 \\
-		105 \amp 145 \amp -95 \amp -155 \\
-		95 \amp 155 \amp -105 \amp -145
-		\end{bmatrix}</m> and
-		<m>A-A_3 = \begin{bmatrix}
-		1 \amp 1 \amp 1 \amp 1 \\
-		-1 \amp -1 \amp -1 \amp -1 \\
-		-1 \amp -1 \amp -1 \amp -1 \\
-		1 \amp 1 \amp 1 \amp 1
-		\end{bmatrix}</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>A_4=A</m>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The entries get closer to <m>0</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-      
+
     </activity>
 
     <p>
@@ -1064,6 +1064,46 @@ data = Gamma2.columns()
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		The fraction of the total variance
+		represented by the first two principal components is
+		<m>97.8\%</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		If <m>\xvec =
+		c_1\uvec_1+c_2\uvec_2+c_3\uvec_3+c_4\uvec_4</m>, then
+		<m>\fourvec{c_1}{c_2}{c_3}{c_4}</m> is the
+		corresponding column of <m>U^TA</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We just need the first two components of the
+		corresponding column of <m>\Gamma</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\twovec{c_1}{c_2}</m> is
+		the corresponding column of <m>U_2^TA</m>.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		We can construct <m>\Gamma_2=\Sigma_2 V_2^T</m> or
+		just pull out the first two rows of <m>\Gamma=\Sigma
+		V^T</m>.
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1123,48 +1163,8 @@ data = Gamma2.columns()
 	  </ol>
 	</p>
       </solution>
-		  
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		The fraction of the total variance
-		represented by the first two principal components is
-		<m>97.8\%</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		If <m>\xvec =
-		c_1\uvec_1+c_2\uvec_2+c_3\uvec_3+c_4\uvec_4</m>, then 
-		<m>\fourvec{c_1}{c_2}{c_3}{c_4}</m> is the
-		corresponding column of <m>U^TA</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We just need the first two components of the
-		corresponding column of <m>\Gamma</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\twovec{c_1}{c_2}</m> is
-		the corresponding column of <m>U_2^TA</m>.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		We can construct <m>\Gamma_2=\Sigma_2 V_2^T</m> or
-		just pull out the first two rows of <m>\Gamma=\Sigma
-		V^T</m>.
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-		  
+
+
     </activity>
 
     <p>
@@ -1431,6 +1431,79 @@ display_matrix(approximate(A, k))
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      <m>\rank(A) = 3</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>\rank(A) = 3</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>k=3</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>123</m>
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      The compression ratio is <m>375/123=3.0</m>
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      The singular values fall off steeply but never
+		      reach <m>0</m>.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      When <m>k=50</m>, the compression ratio is about
+		      <m>3.1</m>.  When <m>k=100</m>, the compression
+		      ratio is about <m>1.6</m>.
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<ol marker="1.">
+		  <li>
+		    <p>
+		      The singular values are similar, but they never
+		      reach <m>0</m>.
+		    </p>
+		  </li>
+		  <li>
+		    <p>
+		      <m>k=3</m> seems like a natural approximation
+		    </p>
+		  </li>
+		</ol>
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1517,80 +1590,7 @@ display_matrix(approximate(A, k))
 	</p>
       </solution>
 
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      <m>\rank(A) = 3</m> 
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>\rank(A) = 3</m> 
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>k=3</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>123</m>
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      The compression ratio is <m>375/123=3.0</m>
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      The singular values fall off steeply but never
-		      reach <m>0</m>.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      When <m>k=50</m>, the compression ratio is about
-		      <m>3.1</m>.  When <m>k=100</m>, the compression
-		      ratio is about <m>1.6</m>.
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<ol marker="1.">
-		  <li>
-		    <p>
-		      The singular values are similar, but they never
-		      reach <m>0</m>.
-		    </p>
-		  </li>
-		  <li>
-		    <p>
-		      <m>k=3</m> seems like a natural approximation
-		    </p>
-		  </li>
-		</ol>
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-      
+
     </activity>
 
     <p>
@@ -1902,6 +1902,71 @@ display_matrix(B.matrix_from_columns(range(50)))
 	</p>
       </statement>
 
+      <answer>
+	<p>
+	  <ol marker="a.">
+	    <li>
+	      <p>
+		The first two singular values contribute most
+		significantly.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\Gamma</m> is a <m>9\times911</m> matrix that
+		expresses the cases as linear combinations of the
+		left singular vectors.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		This is a unanimous decision.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\uvec_1</m> represents a
+		unanimous decision.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		This is a 5-4 decision with the 5 conservative
+		justices voting in the majority.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\uvec_2</m> represents a 5-4 decision.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The most frequently occurring decisions are unanimous
+		and the second most frequently occurring are 5-4.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		<m>\uvec_1</m> represents a
+		case where the five conservative justices are voting
+		together.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		The second left singular vector <m>\uvec_2</m>
+		essentially records the vote of Sandra Day O'Connor.
+	      </p>
+	    </li>
+	    <li>
+	      <p>
+		Sandra Day O'Connor
+	      </p>
+	    </li>
+	  </ol>
+	</p>
+      </answer>
       <solution>
 	<p>
 	  <ol marker="a.">
@@ -1977,73 +2042,8 @@ display_matrix(B.matrix_from_columns(range(50)))
 	  </ol>
 	</p>
       </solution>
-	      
-      <answer>
-	<p>
-	  <ol marker="a.">
-	    <li>
-	      <p>
-		The first two singular values contribute most
-		significantly.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\Gamma</m> is a <m>9\times911</m> matrix that
-		expresses the cases as linear combinations of the
-		left singular vectors.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		This is a unanimous decision.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\uvec_1</m> represents a
-		unanimous decision.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		This is a 5-4 decision with the 5 conservative
-		justices voting in the majority.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\uvec_2</m> represents a 5-4 decision.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The most frequently occurring decisions are unanimous
-		and the second most frequently occurring are 5-4.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		<m>\uvec_1</m> represents a
-		case where the five conservative justices are voting
-		together.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		The second left singular vector <m>\uvec_2</m>
-		essentially records the vote of Sandra Day O'Connor.
-	      </p>
-	    </li>
-	    <li>
-	      <p>
-		Sandra Day O'Connor 
-	      </p>
-	    </li>
-	  </ol>
-	</p>
-      </answer>
-	    
+
+
     </activity>
   </subsection>
 


### PR DESCRIPTION
Fixing up schema violations.  In a `task`, an `answer` has to come before a `solution`.  This PR fixes 385 violations of this type.